### PR TITLE
Add pytest setup and health endpoint test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import importlib
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from models import db
+
+@pytest.fixture(scope='session')
+def app_instance():
+    os.environ.setdefault('DATABASE_URL', 'sqlite:///:memory:')
+    os.environ.setdefault('TWILIO_ACCOUNT_SID', 'dummy')
+    os.environ.setdefault('TWILIO_AUTH_TOKEN', 'dummy')
+    os.environ.setdefault('TWILIO_WHATSAPP_FROM', 'dummy')
+    main = importlib.import_module('main')
+    app = main.app
+    app.config.update(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI='sqlite:///:memory:',
+        SQLALCHEMY_TRACK_MODIFICATIONS=False
+    )
+    return app
+
+@pytest.fixture(scope='function')
+def app(app_instance):
+    with app_instance.app_context():
+        db.drop_all()
+        db.create_all()
+        yield app_instance
+        db.session.remove()
+        db.drop_all()
+
+@pytest.fixture(scope='function')
+def client(app):
+    return app.test_client()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,6 @@
+
+def test_health_check(client):
+    response = client.get('/health')
+    assert response.status_code == 200
+    json_data = response.get_json()
+    assert json_data.get('status') == 'ok'


### PR DESCRIPTION
## Summary
- add pytest fixtures for app and client in tests/conftest.py
- configure app for testing with in-memory SQLite
- add basic health check test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68866cbf5e788333ba4cb9426e35ff07