### PR TITLE
Finalize wallet constraints and OTP auditing

### DIFF
--- a/models/user.py
+++ b/models/user.py
@@ -11,6 +11,7 @@ class OTP(db.Model):
     otp = db.Column(db.String(6), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     is_used = db.Column(db.Boolean, default=False)
+    token = db.Column(db.String(64), nullable=True)
 
     
     def __repr__(self):

--- a/models/wallet.py
+++ b/models/wallet.py
@@ -6,7 +6,7 @@ from models import db
 class ConsumerWallet(db.Model):
     __tablename__ = "consumer_wallet"
     id = Column(Integer, primary_key=True)
-    user_phone = Column(String(15), nullable=False)
+    user_phone = Column(String(15), nullable=False, unique=True)
     balance = Column(Numeric(10, 2), default=0.00)
     created_at = Column(DateTime, default=func.now())
     updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
@@ -38,7 +38,7 @@ class WalletTransaction(db.Model):
 class VendorWallet(db.Model):
     __tablename__ = "vendor_wallet"
     id = Column(Integer, primary_key=True)
-    user_phone = Column(String(15), nullable=False)
+    user_phone = Column(String(15), nullable=False, unique=True)
     balance = Column(Numeric(10, 2), default=0.00)
     created_at = Column(DateTime, default=func.now())
     updated_at = Column(DateTime, default=func.now(), onupdate=func.now())

--- a/services/shop.py
+++ b/services/shop.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from models import db
 from utils.auth_decorator import auth_required
 from utils.role_decorator import role_required
-from models.user import UserProfile
 from models.vendor import VendorProfile
 import logging
 from utils.responses import internal_error_response
@@ -143,7 +142,7 @@ def get_my_shop():
 @auth_required
 @role_required(["vendor"])
 def update_shop_hours():
-    user = UserProfile.query.filter_by(phone=request.phone).first()
+    user = request.user
     shop = Shop.query.filter_by(phone=user.phone).first()
 
     if not shop:

--- a/services/vendor.py
+++ b/services/vendor.py
@@ -1,5 +1,4 @@
 from flask import request, jsonify
-from models.user import UserProfile
 from models.vendor import VendorProfile, VendorDocument, VendorPayoutBank
 from models import db
 from utils.auth_decorator import auth_required
@@ -14,7 +13,7 @@ from utils.responses import internal_error_response
 @auth_required
 @role_required(["vendor"])
 def vendor_profile_setup():
-    user = UserProfile.query.filter_by(phone=request.phone).first()
+    user = request.user
 
     if not user or not user.basic_onboarding_done:
         return jsonify({"status": "error", "message": "Basic onboarding incomplete"}), 400
@@ -55,7 +54,7 @@ def vendor_profile_setup():
 @auth_required
 @role_required(["vendor"])
 def upload_vendor_document():
-    user = UserProfile.query.filter_by(phone=request.phone).first()
+    user = request.user
     data = request.get_json()
 
     doc_type = data.get("document_type")
@@ -84,7 +83,7 @@ def upload_vendor_document():
 @auth_required
 @role_required(["vendor"])
 def setup_payout_bank():
-    user = UserProfile.query.filter_by(phone=request.phone).first()
+    user = request.user
     data = request.get_json()
 
     required_fields = ["bank_name", "account_number", "ifsc_code"]

--- a/services/wallet.py
+++ b/services/wallet.py
@@ -2,7 +2,6 @@
 
 from flask import request, jsonify
 from models import db
-from models.user import UserProfile
 from models.wallet import (
     ConsumerWallet,
     WalletTransaction,
@@ -21,7 +20,8 @@ from utils.responses import internal_error_response
 @auth_required
 @role_required(["consumer"])
 def get_or_create_wallet():
-    user = UserProfile.query.filter_by(phone=request.phone).first()
+    """Return the consumer wallet for the authenticated user, creating one if needed."""
+    user = request.user
     wallet = ConsumerWallet.query.filter_by(user_phone=user.phone).first()
     if not wallet:
         wallet = ConsumerWallet(user_phone=user.phone, balance=Decimal("0.00"))
@@ -49,7 +49,8 @@ def wallet_transaction_history():
 @auth_required
 @role_required(["consumer"])
 def load_wallet():
-    user = UserProfile.query.filter_by(phone=request.phone).first()
+    """Add funds to the authenticated consumer's wallet."""
+    user = request.user
     data = request.get_json()
     amount = Decimal(str(data.get("amount", "0")))
     reference = data.get("reference", "manual-load")
@@ -84,7 +85,8 @@ def load_wallet():
 @auth_required
 @role_required(["consumer"])
 def debit_wallet():
-    user = UserProfile.query.filter_by(phone=request.phone).first()
+    """Deduct funds from the authenticated consumer's wallet."""
+    user = request.user
     data = request.get_json()
     amount = Decimal(str(data.get("amount", "0")))
     reference = data.get("reference", "manual-debit")
@@ -114,7 +116,8 @@ def debit_wallet():
 @auth_required
 @role_required(["consumer"])
 def refund_wallet():
-    user = UserProfile.query.filter_by(phone=request.phone).first()
+    """Refund an amount back to the consumer's wallet, creating it if needed."""
+    user = request.user
     data = request.get_json()
     amount = Decimal(str(data.get("amount", "0")))
     reference = data.get("reference", "manual-refund")
@@ -146,7 +149,8 @@ def refund_wallet():
 @auth_required
 @role_required(["vendor"])
 def get_vendor_wallet():
-    user = UserProfile.query.filter_by(phone=request.phone).first()
+    """Return or create the vendor wallet for the authenticated vendor."""
+    user = request.user
     wallet = VendorWallet.query.filter_by(user_phone=user.phone).first()
     if not wallet:
         wallet = VendorWallet(user_phone=user.phone, balance=Decimal("0.00"))
@@ -174,7 +178,8 @@ def get_vendor_wallet_history():
 @auth_required
 @role_required(["vendor"])
 def credit_vendor_wallet():
-    user = UserProfile.query.filter_by(phone=request.phone).first()
+    """Credit the vendor's wallet with the provided amount."""
+    user = request.user
     data = request.get_json()
     amount = Decimal(str(data.get("amount", "0")))
     reference = data.get("reference", "manual-credit")
@@ -209,7 +214,8 @@ def credit_vendor_wallet():
 @auth_required
 @role_required(["vendor"])
 def debit_vendor_wallet():
-    user = UserProfile.query.filter_by(phone=request.phone).first()
+    """Debit the vendor's wallet if sufficient balance exists."""
+    user = request.user
     data = request.get_json()
     amount = Decimal(str(data.get("amount", "0")))
     reference = data.get("reference", "manual-debit")
@@ -239,7 +245,8 @@ def debit_vendor_wallet():
 @auth_required
 @role_required(["vendor"])
 def withdraw_vendor_wallet():
-    user = UserProfile.query.filter_by(phone=request.phone).first()
+    """Withdraw from the vendor wallet to the configured payout bank."""
+    user = request.user
     data = request.get_json()
     amount = Decimal(str(data.get("amount", "0")))
 


### PR DESCRIPTION
## Summary
- enforce unique phone numbers for wallets
- store issued token on OTP records
- streamline services to use `request.user`
- clean up unused imports and add helpful docstrings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68872c8f50b0833381544091d9d67b65