### PR TITLE
Add environment-based configuration and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+APP_ENV=development
+SECRET_KEY=change-me
+DATABASE_URL=sqlite:///dev.db
+TEST_DATABASE_URL=sqlite:///:memory:
+CORS_ALLOWED_ORIGINS=*
+RATELIMIT_STORAGE_URL=

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,44 @@
+import os
+
+class BaseConfig:
+    JSON_SORT_KEYS = False
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    CORS_ALLOWED_ORIGINS = os.getenv("CORS_ALLOWED_ORIGINS", "*")
+    RATELIMIT_STORAGE_URL = os.getenv("RATELIMIT_STORAGE_URL", "")
+
+class DevelopmentConfig(BaseConfig):
+    DEBUG = True
+    SECRET_KEY = os.getenv("SECRET_KEY", "dev-insecure-key")
+    SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL", "sqlite:///dev.db")
+
+class TestingConfig(BaseConfig):
+    TESTING = True
+    SECRET_KEY = "test-key"
+    SQLALCHEMY_DATABASE_URI = os.getenv("TEST_DATABASE_URL", "sqlite:///:memory:")
+
+class ProductionConfig(BaseConfig):
+    DEBUG = False
+    TESTING = False
+    SECRET_KEY = os.getenv("SECRET_KEY")
+    SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL")
+
+    @staticmethod
+    def validate():
+        missing = []
+        if not os.getenv("SECRET_KEY"):
+            missing.append("SECRET_KEY")
+        if not os.getenv("DATABASE_URL"):
+            missing.append("DATABASE_URL")
+        if missing:
+            raise RuntimeError(
+                f"Missing required env vars in production: {', '.join(missing)}"
+            )
+
+def get_config_class():
+    env = os.getenv("APP_ENV", "development").lower()
+    if env == "production":
+        ProductionConfig.validate()
+        return ProductionConfig
+    if env == "testing":
+        return TestingConfig
+    return DevelopmentConfig

--- a/main.py
+++ b/main.py
@@ -13,20 +13,20 @@ from services import (
 )
 # from agent.query_handler import ask_agent_handler
 from dotenv import load_dotenv
+from app.config import get_config_class
 import os
 import logging
 from flask_cors import CORS
 
-# This will allow all origins by default
-app = Flask(__name__)
-CORS(app)
-
 # --- Load Environment Variables ---
 load_dotenv()
 
-# --- App Setup ---
-app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv("DATABASE_URL")
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+# Create app and load configuration
+app = Flask(__name__)
+app.config.from_object(get_config_class())
+
+# This will allow all origins by default
+CORS(app)
 
 db.init_app(app)
 with app.app_context():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,37 @@
+"""Tests for configuration loading via main.py entrypoint."""
+import importlib
+import os
+import sys
+
+
+def load_app(monkeypatch, env):
+    # set required env vars for services
+    monkeypatch.setenv('TWILIO_ACCOUNT_SID', 'dummy')
+    monkeypatch.setenv('TWILIO_AUTH_TOKEN', 'dummy')
+    monkeypatch.setenv('TWILIO_WHATSAPP_FROM', 'dummy')
+    for key, value in env.items():
+        if value is None:
+            monkeypatch.delenv(key, raising=False)
+        else:
+            monkeypatch.setenv(key, value)
+    # Reload modules with updated environment
+    for module in ['main', 'app.config']:
+        if module in sys.modules:
+            del sys.modules[module]
+    main = importlib.import_module('main')
+    return main.app
+
+
+def test_testing_config_uses_memory_db(monkeypatch):
+    app = load_app(monkeypatch, {'APP_ENV': 'testing'})
+    assert app.config['TESTING'] is True
+    assert app.config['SQLALCHEMY_DATABASE_URI'].startswith('sqlite://')
+
+
+def test_development_defaults(monkeypatch):
+    app = load_app(monkeypatch, {
+        'APP_ENV': 'development',
+        'DATABASE_URL': None,
+    })
+    assert app.config['DEBUG'] is True
+    assert app.config['SQLALCHEMY_DATABASE_URI'] == 'sqlite:///dev.db'


### PR DESCRIPTION
## Summary
- introduce `app/config.py` with environment aware config classes
- load dotenv and config class in `main.py`
- provide `.env.example`
- add tests covering testing and development config loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68872e831f1883339c6d21ae043a84e1