### PR TITLE
Add global error handling

### DIFF
--- a/app/errors.py
+++ b/app/errors.py
@@ -1,0 +1,20 @@
+import logging
+from flask import Blueprint
+from werkzeug.exceptions import HTTPException
+from app.utils.responses import error
+
+errors_bp = Blueprint("errors_bp", __name__)
+
+@errors_bp.app_errorhandler(HTTPException)
+def handle_http_exception(e):
+    msg = e.description or getattr(e, "name", "HTTP Error")
+    return error(msg, status=e.code, code=e.code)
+
+@errors_bp.app_errorhandler(Exception)
+def handle_unexpected_exception(e):
+    logging.exception("Unhandled exception")
+    return error(
+        "An unexpected error occurred. Please try again later.",
+        status=500,
+        code=500,
+    )

--- a/app/test_support.py
+++ b/app/test_support.py
@@ -1,0 +1,15 @@
+from flask import Blueprint
+from app.utils.responses import ok
+
+
+test_support_bp = Blueprint("test_support_bp", __name__)
+
+
+@test_support_bp.route("/__ok", methods=["GET"])
+def __ok():
+    return ok({"ping": "pong"})
+
+
+@test_support_bp.route("/__boom", methods=["GET"])
+def __boom():
+    raise RuntimeError("boom")

--- a/app/utils/responses.py
+++ b/app/utils/responses.py
@@ -1,0 +1,16 @@
+from flask import jsonify
+
+
+def ok(data=None, message="success", status=200):
+    payload = {"status": "success", "message": message}
+    if data is not None:
+        payload["data"] = data
+    return jsonify(payload), status
+
+
+def error(message, status=400, code=None):
+    return jsonify({
+        "status": "error",
+        "message": message,
+        "code": code or status
+    }), status

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ from app.config import get_config_class
 import os
 import logging
 from flask_cors import CORS
+from app.errors import errors_bp
 
 # --- Load Environment Variables ---
 load_dotenv()
@@ -27,6 +28,12 @@ app.config.from_object(get_config_class())
 
 # This will allow all origins by default
 CORS(app)
+
+app.register_blueprint(errors_bp)
+
+if app.config.get("TESTING"):
+    from app.test_support import test_support_bp
+    app.register_blueprint(test_support_bp)
 
 db.init_app(app)
 with app.app_context():

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,51 @@
+import importlib
+import sys
+import pytest
+
+
+def load_app(monkeypatch):
+    monkeypatch.setenv('APP_ENV', 'testing')
+    monkeypatch.setenv('TWILIO_ACCOUNT_SID', 'dummy')
+    monkeypatch.setenv('TWILIO_AUTH_TOKEN', 'dummy')
+    monkeypatch.setenv('TWILIO_WHATSAPP_FROM', 'dummy')
+    for module in ['main', 'app.config']:
+        if module in sys.modules:
+            del sys.modules[module]
+    main = importlib.import_module('main')
+    return main.app
+
+
+@pytest.fixture()
+def test_client(monkeypatch):
+    app = load_app(monkeypatch)
+    app.config.update(TESTING=True)
+    return app.test_client()
+
+
+def test_404_json_envelope(test_client):
+    resp = test_client.get('/no/such/route')
+    assert resp.status_code == 404
+    data = resp.get_json()
+    assert data['status'] == 'error'
+    assert data['code'] == 404
+    assert isinstance(data.get('message'), str)
+
+
+def test_unexpected_500_json_envelope(test_client):
+    resp = test_client.get('/__boom')
+    assert resp.status_code == 500
+    data = resp.get_json()
+    assert data['status'] == 'error'
+    assert data['code'] == 500
+    assert 'RuntimeError' not in data['message']
+
+
+def test_ok_helper_endpoint(test_client):
+    resp = test_client.get('/__ok')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data == {
+        'status': 'success',
+        'message': 'success',
+        'data': {'ping': 'pong'}
+    }


### PR DESCRIPTION
## Summary
- add success/error helper responses
- add blueprint-level handlers for HTTP and unexpected errors
- expose test-only routes for health checks
- register new blueprints in `main.py`
- test JSON error envelopes and helper

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68873609116c83338153395194db3f60