### PR TITLE
Add request ID logging and tests

### DIFF
--- a/app/logging.py
+++ b/app/logging.py
@@ -1,0 +1,42 @@
+import logging
+
+
+def current_request_id():
+    try:
+        from flask import g
+        rid = getattr(g, "request_id", None)
+        return rid or "n/a"
+    except Exception:
+        return "n/a"
+
+
+class RequestIdFilter(logging.Filter):
+    def filter(self, record):
+        try:
+            record.request_id = current_request_id()
+        except Exception:
+            record.request_id = "n/a"
+        return True
+
+
+def configure_logging(app):
+    fmt = "%(asctime)s %(levelname)s %(name)s [%(request_id)s] %(message)s"
+    datefmt = "%Y-%m-%dT%H:%M:%S%z"
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(fmt=fmt, datefmt=datefmt))
+    handler.addFilter(RequestIdFilter())
+
+    app.logger.handlers.clear()
+    app.logger.addHandler(handler)
+    app.logger.setLevel(logging.INFO)
+
+    root = logging.getLogger()
+    if not any(isinstance(h, logging.StreamHandler) for h in root.handlers):
+        root.addHandler(handler)
+    root.setLevel(logging.INFO)
+
+    wl = logging.getLogger("werkzeug")
+    wl.setLevel(logging.INFO)
+    wl.handlers.clear()
+    wl.addHandler(handler)
+

--- a/app/test_support.py
+++ b/app/test_support.py
@@ -1,5 +1,6 @@
 from flask import Blueprint
 from app.utils.responses import ok
+import logging
 
 
 test_support_bp = Blueprint("test_support_bp", __name__)
@@ -13,3 +14,10 @@ def __ok():
 @test_support_bp.route("/__boom", methods=["GET"])
 def __boom():
     raise RuntimeError("boom")
+
+
+@test_support_bp.route("/__log", methods=["GET"])
+def __log():
+    logging.getLogger(__name__).info("test log line")
+    from app.utils.responses import ok
+    return ok({"logged": True})

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,40 @@
+import importlib
+import sys
+
+import pytest
+
+
+def load_app(monkeypatch):
+    monkeypatch.setenv("APP_ENV", "testing")
+    monkeypatch.setenv('TWILIO_ACCOUNT_SID', 'dummy')
+    monkeypatch.setenv('TWILIO_AUTH_TOKEN', 'dummy')
+    monkeypatch.setenv('TWILIO_WHATSAPP_FROM', 'dummy')
+    for module in ["main", "app.config"]:
+        if module in sys.modules:
+            del sys.modules[module]
+    main = importlib.import_module("main")
+    return main.app
+
+
+@pytest.fixture()
+def test_client(monkeypatch):
+    app = load_app(monkeypatch)
+    app.config.update(TESTING=True)
+    return app.test_client()
+
+
+def test_request_id_header_and_propagation(test_client):
+    resp = test_client.get("/__ok", headers={"X-Request-ID": "my-fixed-id-123"})
+    assert resp.status_code == 200
+    assert resp.headers.get("X-Request-ID") == "my-fixed-id-123"
+
+
+def test_logs_include_request_id_attribute(monkeypatch, caplog):
+    app = load_app(monkeypatch)
+    app.config.update(TESTING=True)
+    caplog.set_level("INFO")
+    client = app.test_client()
+    resp = client.get("/__log", headers={"X-Request-ID": "rid-abc"})
+    assert resp.status_code == 200
+    assert any(getattr(r, "request_id", "") == "rid-abc" for r in caplog.records)
+


### PR DESCRIPTION
## Summary
- implement structured logging utilities with per-request IDs
- wire request ID lifecycle hooks into Flask app
- expose a test-only `/__log` endpoint for emitting a log line
- test that X-Request-ID header is echoed and log records contain the ID

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68873d4d11b08333975cb8ac44a9f426