### PR TITLE
Add configurable CORS and security headers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 flask
 flask_sqlalchemy
-flask_cors
+flask-cors>=4.0.0
 python-dotenv
 twilio
 langchain

--- a/tests/test_cors_security.py
+++ b/tests/test_cors_security.py
@@ -1,0 +1,68 @@
+import importlib
+import sys
+
+
+def load_app(monkeypatch, cors_value):
+    monkeypatch.setenv("APP_ENV", "testing")
+    monkeypatch.setenv("CORS_ALLOWED_ORIGINS", cors_value)
+    monkeypatch.setenv('TWILIO_ACCOUNT_SID', 'dummy')
+    monkeypatch.setenv('TWILIO_AUTH_TOKEN', 'dummy')
+    monkeypatch.setenv('TWILIO_WHATSAPP_FROM', 'dummy')
+    for module in ["main", "app.config"]:
+        if module in sys.modules:
+            del sys.modules[module]
+    main = importlib.import_module("main")
+    return main.app
+
+
+def test_cors_preflight_allows_whitelisted_origin(monkeypatch):
+    app = load_app(monkeypatch, "http://localhost:3000,https://app.example.com")
+    app.config.update(TESTING=True)
+    client = app.test_client()
+    resp = client.open(
+        "/__ok",
+        method="OPTIONS",
+        headers={
+            "Origin": "http://localhost:3000",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert resp.status_code in (200, 204)
+    assert resp.headers.get("Access-Control-Allow-Origin") == "http://localhost:3000"
+    vary = resp.headers.get("Vary")
+    if vary:
+        assert "Origin" in vary
+
+
+def test_cors_preflight_blocks_disallowed_origin(monkeypatch):
+    app = load_app(monkeypatch, "https://app.example.com")
+    app.config.update(TESTING=True)
+    client = app.test_client()
+    resp = client.open(
+        "/__ok",
+        method="OPTIONS",
+        headers={
+            "Origin": "http://evil.test",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert resp.status_code in (200, 204)
+    assert "Access-Control-Allow-Origin" not in resp.headers
+
+
+def test_security_headers_and_expose_request_id(monkeypatch):
+    app = load_app(monkeypatch, "*")
+    app.config.update(TESTING=True)
+    client = app.test_client()
+    resp = client.get(
+        "/__ok",
+        headers={"Origin": "http://any.test", "X-Request-ID": "abc-123"},
+    )
+    assert resp.status_code == 200
+    assert resp.headers.get("X-Content-Type-Options") == "nosniff"
+    assert resp.headers.get("X-Frame-Options") == "DENY"
+    assert resp.headers.get("Referrer-Policy") == "no-referrer"
+    assert resp.headers.get("X-Request-ID") == "abc-123"
+    expose = resp.headers.get("Access-Control-Expose-Headers", "")
+    assert "X-Request-ID" in expose
+


### PR DESCRIPTION
## Summary
- add `flask-cors` pinned version to requirements
- configure CORS based on `CORS_ALLOWED_ORIGINS`
- expose X-Request-ID and support credentials
- add security headers after each request
- test CORS behaviour and security headers

## Testing
- `pytest tests/test_cors_security.py::test_cors_preflight_allows_whitelisted_origin -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68873ee0c2448333a3d51f85baac1c36