### PR TITLE
Integrate Flask-Migrate with safe CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Habrio Backend
+
+This repository contains the backend API built with Flask.
+
+## Database Migrations (Flask-Migrate / Alembic)
+
+**Setup (first time in repo):**
+```bash
+export APP_ENV=development  # or testing/staging
+flask db init
+```
+
+**Create a migration:**
+```bash
+flask db-migrate-safe -m "describe change"
+```
+
+**Apply migrations:**
+```bash
+flask db-upgrade-safe
+```
+
+**Stamp an existing database:**
+```bash
+flask db-stamp-safe head
+```
+
+Set `ALLOW_DB_MIGRATIONS=true` in production to permit upgrades or stamping.
+

--- a/app/cli.py
+++ b/app/cli.py
@@ -1,0 +1,49 @@
+import os
+import click
+from flask import current_app
+from flask.cli import with_appcontext
+from flask_migrate import upgrade as alembic_upgrade, stamp as alembic_stamp, migrate as alembic_migrate
+
+
+def _assert_safe_for_upgrade():
+    # Prevent accidental prod upgrades unless explicitly allowed
+    env = (current_app.config.get("ENV") or "").lower()
+    app_env = (os.getenv("APP_ENV") or "").lower()
+    if app_env == "production" or env == "production":
+        if (os.getenv("ALLOW_DB_MIGRATIONS") or "").lower() not in ("1", "true", "yes"):
+            raise click.ClickException("Refusing to run DB migration in production without ALLOW_DB_MIGRATIONS=true")
+
+
+@click.command("db-migrate-safe")
+@click.option("-m", "--message", default="auto migration", help="Migration message")
+@with_appcontext
+def db_migrate_safe(message):
+    """Generate a new migration script from current models."""
+    alembic_migrate(message=message)
+    click.echo("Migration script generated.")
+
+
+@click.command("db-upgrade-safe")
+@with_appcontext
+def db_upgrade_safe():
+    """Apply migrations to the configured database."""
+    _assert_safe_for_upgrade()
+    alembic_upgrade()
+    click.echo("Database upgraded.")
+
+
+@click.command("db-stamp-safe")
+@click.option("--revision", default="head", help="Revision to stamp, default 'head'")
+@with_appcontext
+def db_stamp_safe(revision):
+    """Mark the database at a given revision without running migrations."""
+    _assert_safe_for_upgrade()
+    alembic_stamp(revision)
+    click.echo(f"Database stamped at {revision}.")
+
+
+def register_cli(app):
+    app.cli.add_command(db_migrate_safe)
+    app.cli.add_command(db_upgrade_safe)
+    app.cli.add_command(db_stamp_safe)
+

--- a/main.py
+++ b/main.py
@@ -19,6 +19,8 @@ import logging
 from flask_cors import CORS
 from app.errors import errors_bp
 from app.logging import configure_logging
+from flask_migrate import Migrate
+from app.cli import register_cli
 from flask import request, g
 import uuid
 
@@ -29,6 +31,9 @@ load_dotenv()
 app = Flask(__name__)
 app.config.from_object(get_config_class())
 configure_logging(app)
+register_cli(app)
+from models import user, vendor, shop, item, order, wallet, cart  # noqa: F401
+migrate = Migrate(app, db, compare_type=True, render_as_batch=True)
 
 # Configure CORS based on allowed origins
 allowed = app.config.get("CORS_ALLOWED_ORIGINS", "*")

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ werkzeug
 langchain-community
 psycopg2-binary
 openpyxl
+Flask-Migrate>=4.0.7
+alembic>=1.13.1


### PR DESCRIPTION
## Summary
- add Flask-Migrate and Alembic requirements
- provide CLI wrappers that guard against production usage
- initialize Flask-Migrate in the main entrypoint and register CLI commands
- document how to run migrations

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887426ade14833382f649a412312bec