### PR TITLE
Introduce atomic wallet operations

### DIFF
--- a/app/services/wallet_ops.py
+++ b/app/services/wallet_ops.py
@@ -1,0 +1,76 @@
+from decimal import Decimal, ROUND_HALF_UP
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy import select
+from models.wallet import ConsumerWallet, WalletTransaction, VendorWallet, VendorWalletTransaction
+from models.user import UserProfile
+from models import db
+
+TWOPLACES = Decimal("0.01")
+
+class InsufficientFunds(Exception):
+    pass
+
+def _to_money(value):
+    d = Decimal(str(value))
+    return d.quantize(TWOPLACES, rounding=ROUND_HALF_UP)
+
+def adjust_consumer_balance(user_phone: str, delta, *, reference: str, type: str, source: str = None, status: str = "success"):
+    """
+    Atomically adjust a consumer wallet by 'delta' (Decimal/str/number).
+    Creates a WalletTransaction row in the same DB transaction.
+    Prevents negative balances. Returns new Decimal balance.
+    Does NOT commit; caller is responsible for commit/rollback.
+    """
+    amount = _to_money(delta)
+    wallet = ConsumerWallet.query.filter_by(user_phone=user_phone).with_for_update(of=ConsumerWallet).first()
+    if not wallet:
+        wallet = ConsumerWallet(user_phone=user_phone, balance=_to_money("0"))
+        db.session.add(wallet)
+        db.session.flush()
+
+    new_balance = _to_money(wallet.balance) + amount
+    if new_balance < _to_money("0"):
+        raise InsufficientFunds("Insufficient balance")
+
+    wallet.balance = new_balance
+
+    txn = WalletTransaction(
+        user_phone=user_phone,
+        amount=abs(amount),
+        type=type,
+        reference=reference,
+        status=status,
+        source=source
+    )
+    db.session.add(txn)
+    return new_balance
+
+def adjust_vendor_balance(user_phone: str, delta, *, reference: str, type: str, source: str = None, status: str = "success"):
+    """
+    Atomically adjust a vendor wallet by 'delta'.
+    Creates a VendorWalletTransaction row. Prevents negative balances.
+    Returns new Decimal balance. Does NOT commit.
+    """
+    amount = _to_money(delta)
+
+    wallet = VendorWallet.query.filter_by(user_phone=user_phone).with_for_update(of=VendorWallet).first()
+    if not wallet:
+        wallet = VendorWallet(user_phone=user_phone, balance=_to_money("0"))
+        db.session.add(wallet)
+        db.session.flush()
+
+    new_balance = _to_money(wallet.balance) + amount
+    if new_balance < _to_money("0"):
+        raise InsufficientFunds("Insufficient balance")
+
+    wallet.balance = new_balance
+
+    txn = VendorWalletTransaction(
+        user_phone=user_phone,
+        amount=abs(amount),
+        type=type,
+        reference=reference,
+        status=status
+    )
+    db.session.add(txn)
+    return new_balance

--- a/app/test_support.py
+++ b/app/test_support.py
@@ -1,6 +1,8 @@
-from flask import Blueprint
-from app.utils.responses import ok
+from flask import Blueprint, request
+from app.utils.responses import ok, error
 import logging
+from app.services.wallet_ops import adjust_consumer_balance, adjust_vendor_balance, InsufficientFunds
+from models import db
 
 
 test_support_bp = Blueprint("test_support_bp", __name__)
@@ -21,3 +23,45 @@ def __log():
     logging.getLogger(__name__).info("test log line")
     from app.utils.responses import ok
     return ok({"logged": True})
+
+
+@test_support_bp.route("/__wallet/consumer/adjust", methods=["POST"])
+def __wallet_consumer_adjust():
+    """Adjust consumer wallet for testing."""
+    payload = request.get_json() or {}
+    try:
+        bal = adjust_consumer_balance(
+            payload.get("phone"),
+            payload.get("delta", 0),
+            reference=payload.get("reference", "test"),
+            type=payload.get("type", "recharge"),
+            source="test",
+        )
+        db.session.commit()
+        return ok({"balance": float(bal)})
+    except InsufficientFunds as e:
+        db.session.rollback()
+        return error(str(e), status=400)
+    except Exception:
+        db.session.rollback()
+        return error("wallet op failed", status=500)
+
+
+@test_support_bp.route("/__wallet/vendor/adjust", methods=["POST"])
+def __wallet_vendor_adjust():
+    payload = request.get_json() or {}
+    try:
+        bal = adjust_vendor_balance(
+            payload.get("phone"),
+            payload.get("delta", 0),
+            reference=payload.get("reference", "test"),
+            type=payload.get("type", "credit"),
+        )
+        db.session.commit()
+        return ok({"balance": float(bal)})
+    except InsufficientFunds as e:
+        db.session.rollback()
+        return error(str(e), status=400)
+    except Exception:
+        db.session.rollback()
+        return error("wallet op failed", status=500)

--- a/services/wallet.py
+++ b/services/wallet.py
@@ -14,6 +14,11 @@ from utils.role_decorator import role_required
 from decimal import Decimal
 import logging
 from utils.responses import internal_error_response
+from app.services.wallet_ops import (
+    adjust_consumer_balance,
+    adjust_vendor_balance,
+    InsufficientFunds,
+)
 
 
 # ------------------- Get or Create Consumer Wallet -------------------
@@ -52,33 +57,27 @@ def load_wallet():
     """Add funds to the authenticated consumer's wallet."""
     user = request.user
     data = request.get_json()
-    amount = Decimal(str(data.get("amount", "0")))
-    reference = data.get("reference", "manual-load")
-
-    if amount <= 0:
-        return jsonify({"status": "error", "message": "Invalid amount"}), 400
-
-    wallet = ConsumerWallet.query.filter_by(user_phone=user.phone).first()
-    if not wallet:
-        wallet = ConsumerWallet(user_phone=user.phone, balance=Decimal("0.00"))
-        db.session.add(wallet)
-        db.session.flush()
-
-    wallet.balance += amount
-    db.session.add(WalletTransaction(
-        user_phone=user.phone,
-        amount=amount,
-        type="recharge",
-        reference=reference,
-        status="success"
-    ))
     try:
+        amount = Decimal(str(data.get("amount", "0")))
+        if amount <= 0:
+            return jsonify({"status": "error", "message": "Invalid amount"}), 400
+
+        new_bal = adjust_consumer_balance(
+            user.phone,
+            amount,
+            reference=data.get("reference", "manual-load"),
+            type="recharge",
+            source="api",
+        )
         db.session.commit()
+        return jsonify({"status": "success", "balance": float(new_bal)}), 200
+    except InsufficientFunds as e:
+        db.session.rollback()
+        return jsonify({"status": "error", "message": str(e)}), 400
     except Exception as e:
         db.session.rollback()
         logging.error("Failed to load wallet: %s", e, exc_info=True)
         return internal_error_response()
-    return jsonify({"status": "success", "balance": float(wallet.balance)}), 200
 
 
 # ------------------- Debit Consumer Wallet -------------------
@@ -88,28 +87,26 @@ def debit_wallet():
     """Deduct funds from the authenticated consumer's wallet."""
     user = request.user
     data = request.get_json()
-    amount = Decimal(str(data.get("amount", "0")))
-    reference = data.get("reference", "manual-debit")
-
-    wallet = ConsumerWallet.query.filter_by(user_phone=user.phone).first()
-    if not wallet or wallet.balance < amount:
-        return jsonify({"status": "error", "message": "Insufficient balance"}), 400
-
-    wallet.balance -= amount
-    db.session.add(WalletTransaction(
-        user_phone=user.phone,
-        amount=amount,
-        type="debit",
-        reference=reference,
-        status="success"
-    ))
     try:
+        amount = Decimal(str(data.get("amount", "0")))
+        reference = data.get("reference", "manual-debit")
+
+        new_bal = adjust_consumer_balance(
+            user.phone,
+            -amount,
+            reference=reference,
+            type="debit",
+            source="api",
+        )
         db.session.commit()
+        return jsonify({"status": "success", "balance": float(new_bal)}), 200
+    except InsufficientFunds as e:
+        db.session.rollback()
+        return jsonify({"status": "error", "message": str(e)}), 400
     except Exception as e:
         db.session.rollback()
         logging.error("Failed to debit wallet: %s", e, exc_info=True)
         return internal_error_response()
-    return jsonify({"status": "success", "balance": float(wallet.balance)}), 200
 
 
 # ------------------- Refund to Consumer Wallet -------------------
@@ -119,30 +116,26 @@ def refund_wallet():
     """Refund an amount back to the consumer's wallet, creating it if needed."""
     user = request.user
     data = request.get_json()
-    amount = Decimal(str(data.get("amount", "0")))
-    reference = data.get("reference", "manual-refund")
-
-    wallet = ConsumerWallet.query.filter_by(user_phone=user.phone).first()
-    if not wallet:
-        wallet = ConsumerWallet(user_phone=user.phone, balance=Decimal("0.00"))
-        db.session.add(wallet)
-        db.session.flush()
-
-    wallet.balance += amount
-    db.session.add(WalletTransaction(
-        user_phone=user.phone,
-        amount=amount,
-        type="refund",
-        reference=reference,
-        status="success"
-    ))
     try:
+        amount = Decimal(str(data.get("amount", "0")))
+        reference = data.get("reference", "manual-refund")
+
+        new_bal = adjust_consumer_balance(
+            user.phone,
+            amount,
+            reference=reference,
+            type="refund",
+            source="api",
+        )
         db.session.commit()
+        return jsonify({"status": "success", "balance": float(new_bal)}), 200
+    except InsufficientFunds as e:
+        db.session.rollback()
+        return jsonify({"status": "error", "message": str(e)}), 400
     except Exception as e:
         db.session.rollback()
         logging.error("Failed to refund wallet: %s", e, exc_info=True)
         return internal_error_response()
-    return jsonify({"status": "success", "balance": float(wallet.balance)}), 200
 
 
 # ------------------- Get or Create Vendor Wallet -------------------
@@ -181,33 +174,29 @@ def credit_vendor_wallet():
     """Credit the vendor's wallet with the provided amount."""
     user = request.user
     data = request.get_json()
-    amount = Decimal(str(data.get("amount", "0")))
-    reference = data.get("reference", "manual-credit")
-
-    if amount <= 0:
-        return jsonify({"status": "error", "message": "Invalid credit amount"}), 400
-
-    wallet = VendorWallet.query.filter_by(user_phone=user.phone).first()
-    if not wallet:
-        wallet = VendorWallet(user_phone=user.phone, balance=Decimal("0.00"))
-        db.session.add(wallet)
-        db.session.flush()
-
-    wallet.balance += amount
-    db.session.add(VendorWalletTransaction(
-        user_phone=user.phone,
-        amount=amount,
-        type="credit",
-        reference=reference,
-        status="success"
-    ))
     try:
+        amount = Decimal(str(data.get("amount", "0")))
+        reference = data.get("reference", "manual-credit")
+
+        if amount <= 0:
+            return jsonify({"status": "error", "message": "Invalid credit amount"}), 400
+
+        new_bal = adjust_vendor_balance(
+            user.phone,
+            amount,
+            reference=reference,
+            type="credit",
+            source="api",
+        )
         db.session.commit()
+        return jsonify({"status": "success", "balance": float(new_bal)}), 200
+    except InsufficientFunds as e:
+        db.session.rollback()
+        return jsonify({"status": "error", "message": str(e)}), 400
     except Exception as e:
         db.session.rollback()
         logging.error("Failed to credit vendor wallet: %s", e, exc_info=True)
         return internal_error_response()
-    return jsonify({"status": "success", "balance": float(wallet.balance)}), 200
 
 
 # ------------------- Debit Vendor Wallet -------------------
@@ -217,28 +206,26 @@ def debit_vendor_wallet():
     """Debit the vendor's wallet if sufficient balance exists."""
     user = request.user
     data = request.get_json()
-    amount = Decimal(str(data.get("amount", "0")))
-    reference = data.get("reference", "manual-debit")
-
-    wallet = VendorWallet.query.filter_by(user_phone=user.phone).first()
-    if not wallet or wallet.balance < amount:
-        return jsonify({"status": "error", "message": "Insufficient balance"}), 400
-
-    wallet.balance -= amount
-    db.session.add(VendorWalletTransaction(
-        user_phone=user.phone,
-        amount=amount,
-        type="debit",
-        reference=reference,
-        status="success"
-    ))
     try:
+        amount = Decimal(str(data.get("amount", "0")))
+        reference = data.get("reference", "manual-debit")
+
+        new_bal = adjust_vendor_balance(
+            user.phone,
+            -amount,
+            reference=reference,
+            type="debit",
+            source="api",
+        )
         db.session.commit()
+        return jsonify({"status": "success", "balance": float(new_bal)}), 200
+    except InsufficientFunds as e:
+        db.session.rollback()
+        return jsonify({"status": "error", "message": str(e)}), 400
     except Exception as e:
         db.session.rollback()
         logging.error("Failed to debit vendor wallet: %s", e, exc_info=True)
         return internal_error_response()
-    return jsonify({"status": "success", "balance": float(wallet.balance)}), 200
 
 
 # ------------------- Withdraw Vendor Wallet to Bank -------------------
@@ -248,37 +235,35 @@ def withdraw_vendor_wallet():
     """Withdraw from the vendor wallet to the configured payout bank."""
     user = request.user
     data = request.get_json()
-    amount = Decimal(str(data.get("amount", "0")))
-
-    if amount <= 0:
-        return jsonify({"status": "error", "message": "Invalid withdrawal amount"}), 400
-
-    wallet = VendorWallet.query.filter_by(user_phone=user.phone).first()
-    if not wallet or wallet.balance < amount:
-        return jsonify({"status": "error", "message": "Insufficient balance"}), 400
-
-    bank = VendorPayoutBank.query.filter_by(user_phone=user.phone).first()
-    if not bank:
-        return jsonify({"status": "error", "message": "No payout bank setup found"}), 400
-
-    wallet.balance -= amount
-    db.session.add(VendorWalletTransaction(
-        user_phone=user.phone,
-        amount=amount,
-        type="withdrawal",
-        reference=f"Withdraw to {bank.account_number}",
-        status="success"
-    ))
     try:
+        amount = Decimal(str(data.get("amount", "0")))
+
+        if amount <= 0:
+            return jsonify({"status": "error", "message": "Invalid withdrawal amount"}), 400
+
+        wallet = VendorWallet.query.filter_by(user_phone=user.phone).first()
+        bank = VendorPayoutBank.query.filter_by(user_phone=user.phone).first()
+        if not bank:
+            return jsonify({"status": "error", "message": "No payout bank setup found"}), 400
+
+        new_bal = adjust_vendor_balance(
+            user.phone,
+            -amount,
+            reference=f"Withdraw to {bank.account_number}",
+            type="withdrawal",
+            source="api",
+        )
         db.session.commit()
+        return jsonify({
+            "status": "success",
+            "message": "Withdrawal initiated",
+            "bank_account": bank.account_number,
+            "balance": float(new_bal)
+        }), 200
+    except InsufficientFunds as e:
+        db.session.rollback()
+        return jsonify({"status": "error", "message": str(e)}), 400
     except Exception as e:
         db.session.rollback()
         logging.error("Failed to withdraw vendor wallet: %s", e, exc_info=True)
         return internal_error_response()
-
-    return jsonify({
-        "status": "success",
-        "message": "Withdrawal initiated",
-        "bank_account": bank.account_number,
-        "balance": float(wallet.balance)
-    }), 200

--- a/tests/test_wallet_ops.py
+++ b/tests/test_wallet_ops.py
@@ -1,0 +1,67 @@
+import os, importlib, sys
+from decimal import Decimal
+import pytest
+from models import db
+from models.wallet import ConsumerWallet, WalletTransaction, VendorWallet, VendorWalletTransaction
+
+
+def _reload_entrypoint(monkeypatch):
+    monkeypatch.setenv("APP_ENV", "testing")
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "dummy")
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "dummy")
+    monkeypatch.setenv("TWILIO_WHATSAPP_FROM", "dummy")
+    import main as entry
+    importlib.reload(entry)
+    return entry.app, entry
+
+
+def test_consumer_credit_and_debit_via_helper(monkeypatch):
+    app, entry = _reload_entrypoint(monkeypatch)
+    with app.app_context():
+        db.create_all()
+        client = app.test_client()
+        r = client.post("/__wallet/consumer/adjust", json={"phone": "999", "delta": 100, "type": "recharge", "reference": "t1"})
+        assert r.status_code == 200
+        assert r.get_json()["data"]["balance"] == 100.0
+
+        r = client.post("/__wallet/consumer/adjust", json={"phone": "999", "delta": -30, "type": "debit", "reference": "t2"})
+        assert r.status_code == 200
+        assert r.get_json()["data"]["balance"] == 70.0
+
+        r = client.post("/__wallet/consumer/adjust", json={"phone": "999", "delta": -100, "type": "debit", "reference": "t3"})
+        assert r.status_code == 400
+
+        w = ConsumerWallet.query.filter_by(user_phone="999").first()
+        assert float(w.balance) == 70.0
+        txns = WalletTransaction.query.filter_by(user_phone="999").all()
+        assert len(txns) == 2
+
+
+def test_vendor_credit_and_withdraw(monkeypatch):
+    app, entry = _reload_entrypoint(monkeypatch)
+    with app.app_context():
+        db.create_all()
+        client = app.test_client()
+        r = client.post("/__wallet/vendor/adjust", json={"phone": "888", "delta": 250, "type": "credit", "reference": "v1"})
+        assert r.status_code == 200
+        assert r.get_json()["data"]["balance"] == 250.0
+
+        r = client.post("/__wallet/vendor/adjust", json={"phone": "888", "delta": -100, "type": "withdrawal", "reference": "v2"})
+        assert r.status_code == 200
+        assert r.get_json()["data"]["balance"] == 150.0
+
+        w = VendorWallet.query.filter_by(user_phone="888").first()
+        assert float(w.balance) == 150.0
+        txns = VendorWalletTransaction.query.filter_by(user_phone="888").all()
+        assert len(txns) == 2
+
+
+def test_wallet_service_endpoints_use_helpers(monkeypatch):
+    app, entry = _reload_entrypoint(monkeypatch)
+    with app.app_context():
+        db.create_all()
+        client = app.test_client()
+        client.post("/__wallet/consumer/adjust", json={"phone": "777", "delta": 50, "type": "recharge", "reference": "s1"})
+        r = client.post("/__wallet/consumer/adjust", json={"phone": "777", "delta": -60, "type": "debit", "reference": "s2"})
+        assert r.status_code == 400
+


### PR DESCRIPTION
## Summary
- add atomic wallet adjustment helpers
- expose testing endpoints for wallet adjustments
- refactor wallet service functions to use new helpers
- add regression tests for helper functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688746a2a0e48333891379f15af8bdeb