### PR TITLE
Introduce API v1 routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ flask db-stamp-safe head
 
 Set `ALLOW_DB_MIGRATIONS=true` in production to permit upgrades or stamping.
 
+
+## API Versioning
+- All business endpoints are now served under `/api/v1/...`.
+- Error handlers remain global (no prefix).
+- Test-only routes remain unversioned and, in testing, also available under `/api/v1/test_support/...`.
+- Clients should update their base path to `/api/v1`.

--- a/app/api.py
+++ b/app/api.py
@@ -1,0 +1,108 @@
+from app.version import API_PREFIX
+
+
+def _join_prefix(*parts):
+    s = "/".join(p.strip("/") for p in parts if p is not None and p != "")
+    return "/" + s if not s.startswith("/") else s
+
+
+def register_api_v1(app):
+    """Register business endpoints under the API version prefix."""
+    # Import here to avoid circular dependencies
+    from services import (
+        auth as auth_services,
+        user as user_services,
+        vendor as vendor_services,
+        shop as shop_services,
+        item as item_services,
+        cart as cart_services,
+        wallet as wallet_services,
+        consumerorder as consumer_order_services,
+        vendororder as vendor_order_services,
+    )
+
+    def j(path: str) -> str:
+        return _join_prefix(API_PREFIX, path)
+
+    add = app.add_url_rule
+
+    # Auth and onboarding
+    add(j("/send-otp"), view_func=auth_services.send_otp_handler, methods=["POST"])
+    add(j("/verify-otp"), view_func=auth_services.verify_otp_handler, methods=["POST"])
+    add(j("/logout"), view_func=auth_services.logout_handler, methods=["POST"])
+    add(j("/onboarding/basic"), view_func=user_services.basic_onboarding, methods=["POST"])
+
+    # Consumer routes
+    add(j("/onboarding/consumer"), view_func=user_services.consumer_onboarding, methods=["POST"])
+
+    add(j("/profile/me"), view_func=user_services.get_consumer_profile, methods=["GET"])
+    add(j("/profile/edit"), view_func=user_services.edit_consumer_profile, methods=["POST"])
+
+    # Wallet
+    add(j("/wallet"), view_func=wallet_services.get_or_create_wallet, methods=["GET"])
+    add(j("/wallet/history"), view_func=wallet_services.wallet_transaction_history, methods=["GET"])
+    add(j("/wallet/load"), view_func=wallet_services.load_wallet, methods=["POST"])
+    add(j("/wallet/debit"), view_func=wallet_services.debit_wallet, methods=["POST"])
+    add(j("/wallet/refund"), view_func=wallet_services.refund_wallet, methods=["POST"])
+
+    # Shops & Items
+    add(j("/shops"), view_func=shop_services.list_shops, methods=["GET"])
+    add(j("/shops/search"), view_func=shop_services.search_shops, methods=["GET"])
+    add(j("/items/shop/<int:shop_id>"), view_func=item_services.view_items_by_shop, methods=["GET"])
+
+    # Cart
+    add(j("/cart/add"), view_func=cart_services.add_to_cart, methods=["POST"])
+    add(j("/cart/view"), view_func=cart_services.view_cart, methods=["GET"])
+    add(j("/cart/update"), view_func=cart_services.update_cart_quantity, methods=["POST"])
+    add(j("/cart/remove"), view_func=cart_services.remove_item, methods=["POST"])
+    add(j("/cart/clear"), view_func=cart_services.clear_cart, methods=["POST"])
+
+    # Consumer Orders
+    add(j("/order/confirm"), view_func=consumer_order_services.confirm_order, methods=["POST"])
+    add(j("/order/history"), view_func=consumer_order_services.get_order_history, methods=["GET"])
+    add(j("/order/consumer/confirm-modified/<int:order_id>"), view_func=consumer_order_services.confirm_modified_order, methods=["POST"])
+    add(j("/order/consumer/cancel/<int:order_id>"), view_func=consumer_order_services.cancel_order_consumer, methods=["POST"])
+    add(j("/order/consumer/message/send/<int:order_id>"), view_func=consumer_order_services.send_order_message_consumer, methods=["POST"])
+    add(j("/order/consumer/messages/<int:order_id>"), view_func=consumer_order_services.get_order_messages_consumer, methods=["GET"])
+    add(j("/order/rate/<int:order_id>"), view_func=consumer_order_services.rate_order, methods=["POST"])
+    add(j("/order/issue/<int:order_id>"), view_func=consumer_order_services.raise_order_issue, methods=["POST"])
+    add(j("/order/return/raise/<int:order_id>"), view_func=consumer_order_services.request_return, methods=["POST"])
+
+    # Vendor routes - onboarding and shop setup
+    add(j("/vendor/profile"), view_func=vendor_services.vendor_profile_setup, methods=["POST"])
+    add(j("/vendor/upload-document"), view_func=vendor_services.upload_vendor_document, methods=["POST"])
+    add(j("/vendor/create-shop"), view_func=shop_services.create_shop, methods=["POST"])
+    add(j("/vendor/payout/setup"), view_func=vendor_services.setup_payout_bank, methods=["POST"])
+
+    # Shop management
+    add(j("/shop/update-hours"), view_func=shop_services.update_shop_hours, methods=["POST"])
+    add(j("/shop/edit"), view_func=shop_services.edit_shop, methods=["POST"])
+    add(j("/shop/my"), view_func=shop_services.get_my_shop, methods=["GET"])
+    add(j("/vendor/shop/toggle_status"), view_func=shop_services.toggle_shop_status, methods=["POST"])
+
+    # Items
+    add(j("/item/add"), view_func=item_services.add_item, methods=["POST"])
+    add(j("/item/bulk-upload"), view_func=item_services.bulk_upload_items, methods=["POST"])
+    add(j("/item/<int:item_id>/toggle"), view_func=item_services.toggle_item_availability, methods=["POST"])
+    add(j("/item/update/<int:item_id>"), view_func=item_services.update_item, methods=["POST"])
+    add(j("/item/my"), view_func=item_services.get_items, methods=["GET"])
+
+    # Vendor Wallet
+    add(j("/vendor/wallet"), view_func=wallet_services.get_vendor_wallet, methods=["GET"])
+    add(j("/vendor/wallet/history"), view_func=wallet_services.get_vendor_wallet_history, methods=["GET"])
+    add(j("/vendor/wallet/credit"), view_func=wallet_services.credit_vendor_wallet, methods=["POST"])
+    add(j("/vendor/wallet/debit"), view_func=wallet_services.debit_vendor_wallet, methods=["POST"])
+    add(j("/vendor/wallet/withdraw"), view_func=wallet_services.withdraw_vendor_wallet, methods=["POST"])
+
+    # Vendor Orders
+    add(j("/order/vendor"), view_func=vendor_order_services.get_shop_orders, methods=["GET"])
+    add(j("/order/vendor/status/<int:order_id>"), view_func=vendor_order_services.update_order_status, methods=["POST"])
+    add(j("/order/vendor/modify/<int:order_id>"), view_func=vendor_order_services.modify_order_item, methods=["POST"])
+    add(j("/order/vendor/cancel/<int:order_id>"), view_func=vendor_order_services.cancel_order_vendor, methods=["POST"])
+    add(j("/order/vendor/message/send/<int:order_id>"), view_func=vendor_order_services.send_order_message_vendor, methods=["POST"])
+    add(j("/order/vendor/messages/<int:order_id>"), view_func=vendor_order_services.get_order_messages_vendor, methods=["GET"])
+    add(j("/order/vendor/issues"), view_func=vendor_order_services.get_issues_for_order, methods=["GET"])
+    add(j("/order/return/vendor/accept/<int:order_id>"), view_func=vendor_order_services.accept_return, methods=["POST"])
+    add(j("/order/return/complete/<int:order_id>"), view_func=vendor_order_services.complete_return, methods=["POST"])
+    add(j("/order/return/vendor/initiate/<int:order_id>"), view_func=vendor_order_services.vendor_initiate_return, methods=["POST"])
+

--- a/app/version.py
+++ b/app/version.py
@@ -1,0 +1,2 @@
+API_VERSION = "v1"
+API_PREFIX = f"/api/{API_VERSION}"

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ from app.logging import configure_logging
 from flask_migrate import Migrate
 from app.cli import register_cli
 from flask import request, g
+from app.api import register_api_v1
 import uuid
 
 # --- Load Environment Variables ---
@@ -55,6 +56,7 @@ app.register_blueprint(errors_bp)
 if app.config.get("TESTING"):
     from app.test_support import test_support_bp
     app.register_blueprint(test_support_bp)
+    app.register_blueprint(test_support_bp, url_prefix="/api/v1/test_support", name="test_support_bp_v1")
 
 @app.before_request
 def _set_request_id():
@@ -95,92 +97,11 @@ with app.app_context():
     logging.info("✅ Tables created")
 
 # ========================== Health Check ==========================
+register_api_v1(app)
 @app.route("/health")
 def health():
     return {"status": "ok", "base_url": "https://2e6bee57-c137-4144-90f2-64265943227d-00-c6d7jiueybzk.pike.replit.dev"}, 200
 
-# ===================== Auth Routes and basic onboarding ====================
-app.add_url_rule("/send-otp", view_func=auth_services.send_otp_handler, methods=["POST"])
-app.add_url_rule("/verify-otp", view_func=auth_services.verify_otp_handler, methods=["POST"])
-app.add_url_rule("/logout", view_func=auth_services.logout_handler, methods=["POST"])
-app.add_url_rule("/onboarding/basic", view_func=user_services.basic_onboarding, methods=["POST"])
-
-# ========================== Consumer Routes ==========================
-# Onboarding
-app.add_url_rule("/onboarding/consumer", view_func=user_services.consumer_onboarding, methods=["POST"])
-
-# Profile
-app.add_url_rule("/profile/me", view_func=user_services.get_consumer_profile, methods=["GET"])
-app.add_url_rule("/profile/edit", view_func=user_services.edit_consumer_profile, methods=["POST"])
-
-# Wallet
-app.add_url_rule("/wallet", view_func=wallet_services.get_or_create_wallet, methods=["GET"])
-app.add_url_rule("/wallet/history", view_func=wallet_services.wallet_transaction_history, methods=["GET"])
-app.add_url_rule("/wallet/load", view_func=wallet_services.load_wallet, methods=["POST"])
-app.add_url_rule("/wallet/debit", view_func=wallet_services.debit_wallet, methods=["POST"])
-app.add_url_rule("/wallet/refund", view_func=wallet_services.refund_wallet, methods=["POST"])
-
-# Shops & Items
-app.add_url_rule("/shops", view_func=shop_services.list_shops, methods=["GET"])
-app.add_url_rule("/shops/search", view_func=shop_services.search_shops, methods=["GET"])
-app.add_url_rule("/items/shop/<int:shop_id>", view_func=item_services.view_items_by_shop, methods=["GET"])
-
-# Cart
-app.add_url_rule("/cart/add", view_func=cart_services.add_to_cart, methods=["POST"])
-app.add_url_rule("/cart/view", view_func=cart_services.view_cart, methods=["GET"])
-app.add_url_rule("/cart/update", view_func=cart_services.update_cart_quantity, methods=["POST"])
-app.add_url_rule("/cart/remove", view_func=cart_services.remove_item, methods=["POST"])
-app.add_url_rule("/cart/clear", view_func=cart_services.clear_cart, methods=["POST"])
-
-# Consumer Orders
-app.add_url_rule("/order/confirm", view_func=consumer_order_services.confirm_order, methods=["POST"])
-app.add_url_rule("/order/history", view_func=consumer_order_services.get_order_history, methods=["GET"])
-app.add_url_rule("/order/consumer/confirm-modified/<int:order_id>", view_func=consumer_order_services.confirm_modified_order, methods=["POST"])
-app.add_url_rule("/order/consumer/cancel/<int:order_id>", view_func=consumer_order_services.cancel_order_consumer, methods=["POST"])
-app.add_url_rule("/order/consumer/message/send/<int:order_id>", view_func=consumer_order_services.send_order_message_consumer, methods=["POST"])
-app.add_url_rule("/order/consumer/messages/<int:order_id>", view_func=consumer_order_services.get_order_messages_consumer, methods=["GET"])
-app.add_url_rule("/order/rate/<int:order_id>", view_func=consumer_order_services.rate_order, methods=["POST"])
-app.add_url_rule("/order/issue/<int:order_id>", view_func=consumer_order_services.raise_order_issue, methods=["POST"])
-app.add_url_rule("/order/return/raise/<int:order_id>", view_func=consumer_order_services.request_return, methods=["POST"])
-
-# ========================== Vendor Routes ==========================
-# Onboarding & Shop Setup
-app.add_url_rule("/vendor/profile", view_func=vendor_services.vendor_profile_setup, methods=["POST"])
-app.add_url_rule("/vendor/upload-document", view_func=vendor_services.upload_vendor_document, methods=["POST"])
-app.add_url_rule("/vendor/create-shop", view_func=shop_services.create_shop, methods=["POST"])
-app.add_url_rule("/vendor/payout/setup", view_func=vendor_services.setup_payout_bank, methods=["POST"])
-
-# Shop Management
-app.add_url_rule("/shop/update-hours", view_func=shop_services.update_shop_hours, methods=["POST"])
-app.add_url_rule("/shop/edit", view_func=shop_services.edit_shop, methods=["POST"])
-app.add_url_rule("/shop/my", view_func=shop_services.get_my_shop, methods=["GET"])
-app.add_url_rule("/vendor/shop/toggle_status", view_func=shop_services.toggle_shop_status, methods=["POST"])
-
-# Items
-app.add_url_rule("/item/add", view_func=item_services.add_item, methods=["POST"])
-app.add_url_rule("/item/bulk-upload", view_func=item_services.bulk_upload_items, methods=["POST"])
-app.add_url_rule("/item/<int:item_id>/toggle", view_func=item_services.toggle_item_availability, methods=["POST"])
-app.add_url_rule("/item/update/<int:item_id>", view_func=item_services.update_item, methods=["POST"])
-app.add_url_rule("/item/my", view_func=item_services.get_items, methods=["GET"])
-
-# Vendor Wallet
-app.add_url_rule("/vendor/wallet", view_func=wallet_services.get_vendor_wallet, methods=["GET"])
-app.add_url_rule("/vendor/wallet/history", view_func=wallet_services.get_vendor_wallet_history, methods=["GET"])
-app.add_url_rule("/vendor/wallet/credit", view_func=wallet_services.credit_vendor_wallet, methods=["POST"])
-app.add_url_rule("/vendor/wallet/debit", view_func=wallet_services.debit_vendor_wallet, methods=["POST"])
-app.add_url_rule("/vendor/wallet/withdraw", view_func=wallet_services.withdraw_vendor_wallet, methods=["POST"])
-
-# Vendor Orders
-app.add_url_rule("/order/vendor", view_func=vendor_order_services.get_shop_orders, methods=["GET"])
-app.add_url_rule("/order/vendor/status/<int:order_id>", view_func=vendor_order_services.update_order_status, methods=["POST"])
-app.add_url_rule("/order/vendor/modify/<int:order_id>", view_func=vendor_order_services.modify_order_item, methods=["POST"])
-app.add_url_rule("/order/vendor/cancel/<int:order_id>", view_func=vendor_order_services.cancel_order_vendor, methods=["POST"])
-app.add_url_rule("/order/vendor/message/send/<int:order_id>", view_func=vendor_order_services.send_order_message_vendor, methods=["POST"])
-app.add_url_rule("/order/vendor/messages/<int:order_id>", view_func=vendor_order_services.get_order_messages_vendor, methods=["GET"])
-app.add_url_rule("/order/vendor/issues", view_func=vendor_order_services.get_issues_for_order, methods=["GET"])
-app.add_url_rule("/order/return/vendor/accept/<int:order_id>", view_func=vendor_order_services.accept_return, methods=["POST"])
-app.add_url_rule("/order/return/complete/<int:order_id>", view_func=vendor_order_services.complete_return, methods=["POST"])
-app.add_url_rule("/order/return/vendor/initiate/<int:order_id>", view_func=vendor_order_services.vendor_initiate_return, methods=["POST"])
 
 # ========================== Run ==========================
 if __name__ == "__main__":

--- a/tests/test_api_versioning.py
+++ b/tests/test_api_versioning.py
@@ -1,0 +1,43 @@
+import sys
+import importlib
+import pytest
+from werkzeug.routing import Rule
+
+
+def _load_app(monkeypatch):
+    monkeypatch.setenv("APP_ENV", "testing")
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "dummy")
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "dummy")
+    monkeypatch.setenv("TWILIO_WHATSAPP_FROM", "dummy")
+    for m in ["main", "app.config", "app.test_support"]:
+        if m in sys.modules:
+            del sys.modules[m]
+    import main as entry
+    importlib.reload(entry)
+    return entry.app
+
+
+def test_test_support_unversioned_still_works(monkeypatch):
+    app = _load_app(monkeypatch)
+    c = app.test_client()
+    r = c.get("/__ok")
+    assert r.status_code == 200
+    js = r.get_json()
+    assert js["status"] == "success"
+    assert js["data"]["ping"] == "pong"
+
+
+def test_test_support_also_available_under_api_v1(monkeypatch):
+    app = _load_app(monkeypatch)
+    c = app.test_client()
+    r = c.get("/api/v1/test_support/__ok")
+    assert r.status_code == 200
+    js = r.get_json()
+    assert js["status"] == "success"
+    assert js["data"]["ping"] == "pong"
+
+
+def test_url_map_contains_api_v1_rules(monkeypatch):
+    app = _load_app(monkeypatch)
+    prefixes = {str(r.rule) for r in app.url_map.iter_rules()}
+    assert any(p.startswith("/api/v1/") for p in prefixes)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,20 +1,21 @@
 import pytest
 from models.user import OTP, UserProfile
+from app.version import API_PREFIX
 
 
 def send_otp(client, phone):
-    return client.post('/send-otp', json={'phone': phone})
+    return client.post(f"{API_PREFIX}/send-otp", json={'phone': phone})
 
 
 def verify_otp(client, phone, otp):
-    return client.post('/verify-otp', json={'phone': phone, 'otp': otp})
+    return client.post(f"{API_PREFIX}/verify-otp", json={'phone': phone, 'otp': otp})
 
 
 def logout(client, token=None):
     headers = {}
     if token:
         headers['Authorization'] = token
-    return client.post('/logout', headers=headers)
+    return client.post(f"{API_PREFIX}/logout", headers=headers)
 
 
 def basic_onboarding(client, token):
@@ -25,7 +26,7 @@ def basic_onboarding(client, token):
         'society': 'Society',
         'role': 'consumer'
     }
-    return client.post('/onboarding/basic', json=payload, headers=headers)
+    return client.post(f"{API_PREFIX}/onboarding/basic", json=payload, headers=headers)
 
 
 def test_send_otp_success_and_db_entry(client, app):
@@ -40,7 +41,7 @@ def test_send_otp_success_and_db_entry(client, app):
 
 
 def test_send_otp_no_phone(client):
-    response = client.post('/send-otp', json={})
+    response = client.post('/api/v1/send-otp', json={})
     assert response.status_code == 400
     assert response.get_json()['status'] == 'error'
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,14 +1,15 @@
 import pytest
 from models.user import OTP, UserProfile, ConsumerProfile
 from models import db
+from app.version import API_PREFIX
 
 
 def send_otp(client, phone):
-    return client.post('/send-otp', json={'phone': phone})
+    return client.post(f"{API_PREFIX}/send-otp", json={'phone': phone})
 
 
 def verify_otp(client, phone, otp):
-    return client.post('/verify-otp', json={'phone': phone, 'otp': otp})
+    return client.post(f"{API_PREFIX}/verify-otp", json={'phone': phone, 'otp': otp})
 
 
 def do_basic_onboarding(client, token, name='User', city='Town', society='Society', role='consumer'):
@@ -18,19 +19,19 @@ def do_basic_onboarding(client, token, name='User', city='Town', society='Societ
         'society': society,
         'role': role
     }
-    return client.post('/onboarding/basic', json=payload, headers={'Authorization': token})
+    return client.post(f"{API_PREFIX}/onboarding/basic", json=payload, headers={'Authorization': token})
 
 
 def do_consumer_onboarding(client, token, **extra):
-    return client.post('/onboarding/consumer', json=extra, headers={'Authorization': token})
+    return client.post(f"{API_PREFIX}/onboarding/consumer", json=extra, headers={'Authorization': token})
 
 
 def get_profile(client, token):
-    return client.get('/profile/me', headers={'Authorization': token})
+    return client.get(f"{API_PREFIX}/profile/me", headers={'Authorization': token})
 
 
 def edit_profile(client, token, data):
-    return client.post('/profile/edit', json=data, headers={'Authorization': token})
+    return client.post(f"{API_PREFIX}/profile/edit", json=data, headers={'Authorization': token})
 
 
 
@@ -59,7 +60,7 @@ def test_basic_onboarding_success(client, app):
 def test_basic_onboarding_missing_fields(client, app):
     phone = '9900022222'
     token = obtain_token(client, app, phone)
-    resp = client.post('/onboarding/basic', json={'name': 'Bob'}, headers={'Authorization': token})
+    resp = client.post('/api/v1/onboarding/basic', json={'name': 'Bob'}, headers={'Authorization': token})
     assert resp.status_code == 400
     assert resp.get_json()['message'] == 'Missing fields'
 

--- a/tests/test_vendor.py
+++ b/tests/test_vendor.py
@@ -2,14 +2,15 @@ import pytest
 from models.user import OTP, UserProfile
 from models.vendor import VendorProfile, VendorDocument, VendorPayoutBank
 from models import db
+from app.version import API_PREFIX
 
 
 def send_otp(client, phone):
-    return client.post('/send-otp', json={'phone': phone})
+    return client.post(f"{API_PREFIX}/send-otp", json={'phone': phone})
 
 
 def verify_otp(client, phone, otp):
-    return client.post('/verify-otp', json={'phone': phone, 'otp': otp})
+    return client.post(f"{API_PREFIX}/verify-otp", json={'phone': phone, 'otp': otp})
 
 
 def obtain_token(client, app, phone):
@@ -27,7 +28,7 @@ def do_basic_onboarding(client, token, role='vendor'):
         'society': 'Society',
         'role': role
     }
-    return client.post('/onboarding/basic', json=payload, headers={'Authorization': token})
+    return client.post(f"{API_PREFIX}/onboarding/basic", json=payload, headers={'Authorization': token})
 
 
 def test_vendor_profile_setup_success(client, app):
@@ -41,7 +42,7 @@ def test_vendor_profile_setup_success(client, app):
         'gst_number': 'GST123',
         'address': '123 Market'
     }
-    resp = client.post('/vendor/profile', json=payload, headers={'Authorization': token})
+    resp = client.post('/api/v1/vendor/profile', json=payload, headers={'Authorization': token})
     assert resp.status_code == 200
     with app.app_context():
         profile = VendorProfile.query.filter_by(user_phone=phone).first()
@@ -59,7 +60,7 @@ def test_vendor_profile_requires_basic_onboarding(client, app):
         user.role = 'vendor'
         db.session.commit()
 
-    resp = client.post('/vendor/profile', json={'business_type': 'retail', 'business_name': 'Test', 'address': 'Addr'}, headers={'Authorization': token})
+    resp = client.post('/api/v1/vendor/profile', json={'business_type': 'retail', 'business_name': 'Test', 'address': 'Addr'}, headers={'Authorization': token})
     assert resp.status_code == 400
     assert resp.get_json()['message'] == 'Basic onboarding incomplete'
 
@@ -69,7 +70,7 @@ def test_vendor_profile_missing_fields_and_duplicate(client, app):
     token = obtain_token(client, app, phone)
     do_basic_onboarding(client, token, role='vendor')
     # Missing fields
-    resp = client.post('/vendor/profile', json={'business_name': 'A'}, headers={'Authorization': token})
+    resp = client.post('/api/v1/vendor/profile', json={'business_name': 'A'}, headers={'Authorization': token})
     assert resp.status_code == 400
     assert resp.get_json()['message'] == 'Missing required vendor details'
 
@@ -79,9 +80,9 @@ def test_vendor_profile_missing_fields_and_duplicate(client, app):
         'business_name': 'Shop',
         'address': 'Addr'
     }
-    assert client.post('/vendor/profile', json=payload, headers={'Authorization': token}).status_code == 200
+    assert client.post('/api/v1/vendor/profile', json=payload, headers={'Authorization': token}).status_code == 200
     # Second attempt should fail
-    resp_again = client.post('/vendor/profile', json=payload, headers={'Authorization': token})
+    resp_again = client.post('/api/v1/vendor/profile', json=payload, headers={'Authorization': token})
     assert resp_again.status_code == 400
     assert resp_again.get_json()['message'] == 'Vendor profile already exists'
 
@@ -90,15 +91,15 @@ def test_upload_vendor_document(client, app):
     phone = '8000000004'
     token = obtain_token(client, app, phone)
     do_basic_onboarding(client, token, role='vendor')
-    client.post('/vendor/profile', json={'business_type': 'retail', 'business_name': 'Shop', 'address': 'Addr'}, headers={'Authorization': token})
+    client.post('/api/v1/vendor/profile', json={'business_type': 'retail', 'business_name': 'Shop', 'address': 'Addr'}, headers={'Authorization': token})
 
-    resp = client.post('/vendor/upload-document', json={'document_type': 'aadhaar', 'file_url': 'http://file'}, headers={'Authorization': token})
+    resp = client.post('/api/v1/vendor/upload-document', json={'document_type': 'aadhaar', 'file_url': 'http://file'}, headers={'Authorization': token})
     assert resp.status_code == 200
     with app.app_context():
         doc = VendorDocument.query.filter_by(vendor_phone=phone, document_type='aadhaar').first()
         assert doc is not None
 
-    resp_fail = client.post('/vendor/upload-document', json={'document_type': 'aadhaar'}, headers={'Authorization': token})
+    resp_fail = client.post('/api/v1/vendor/upload-document', json={'document_type': 'aadhaar'}, headers={'Authorization': token})
     assert resp_fail.status_code == 400
 
 
@@ -106,10 +107,10 @@ def test_setup_payout_bank_create_and_update(client, app):
     phone = '8000000005'
     token = obtain_token(client, app, phone)
     do_basic_onboarding(client, token, role='vendor')
-    client.post('/vendor/profile', json={'business_type': 'retail', 'business_name': 'Shop', 'address': 'Addr'}, headers={'Authorization': token})
+    client.post('/api/v1/vendor/profile', json={'business_type': 'retail', 'business_name': 'Shop', 'address': 'Addr'}, headers={'Authorization': token})
 
     data1 = {'bank_name': 'BankA', 'account_number': '111', 'ifsc_code': 'IFSC1'}
-    resp1 = client.post('/vendor/payout/setup', json=data1, headers={'Authorization': token})
+    resp1 = client.post('/api/v1/vendor/payout/setup', json=data1, headers={'Authorization': token})
     assert resp1.status_code == 200
     with app.app_context():
         bank = VendorPayoutBank.query.filter_by(user_phone=phone).first()
@@ -117,7 +118,7 @@ def test_setup_payout_bank_create_and_update(client, app):
         assert bank.bank_name == 'BankA'
 
     data2 = {'bank_name': 'BankB', 'account_number': '222', 'ifsc_code': 'IFSC2'}
-    resp2 = client.post('/vendor/payout/setup', json=data2, headers={'Authorization': token})
+    resp2 = client.post('/api/v1/vendor/payout/setup', json=data2, headers={'Authorization': token})
     assert resp2.status_code == 200
     with app.app_context():
         banks = VendorPayoutBank.query.filter_by(user_phone=phone).all()
@@ -125,5 +126,5 @@ def test_setup_payout_bank_create_and_update(client, app):
         assert banks[0].bank_name == 'BankB'
         assert banks[0].account_number == '222'
 
-    resp_fail = client.post('/vendor/payout/setup', json={'bank_name': 'BankX'}, headers={'Authorization': token})
+    resp_fail = client.post('/api/v1/vendor/payout/setup', json={'bank_name': 'BankX'}, headers={'Authorization': token})
     assert resp_fail.status_code == 400


### PR DESCRIPTION
## Summary
- centralize API version constants
- add register_api_v1 function to mount business endpoints under `/api/v1`
- adjust main entrypoint to use new registration and mount versioned test blueprint
- update all tests for versioned routes and add API versioning tests
- document API versioning in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68879ce543748333919d96e872ffdcaa