### PR TITLE
Implement JWT auth with refresh tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ Set `ALLOW_DB_MIGRATIONS=true` in production to permit upgrades or stamping.
 - Error handlers remain global (no prefix).
 - Test-only routes remain unversioned and, in testing, also available under `/api/v1/test_support/...`.
 - Clients should update their base path to `/api/v1`.
+
+### Auth
+
+* Access token (lifetime ≈ 15 min) – send via `Authorization: Bearer <token>`.
+* Refresh token (lifetime ≈ 30 days) – POST to `/api/v1/auth/refresh` to obtain new pair.
+* Tokens are signed HS256 with `JWT_SECRET`.

--- a/app/api.py
+++ b/app/api.py
@@ -26,6 +26,9 @@ def register_api_v1(app):
 
     add = app.add_url_rule
 
+    # JWT auth refresh
+    app.register_blueprint(auth_services.auth_bp, url_prefix=_join_prefix(API_PREFIX, "auth"))
+
     # Auth and onboarding
     add(j("/send-otp"), view_func=auth_services.send_otp_handler, methods=["POST"])
     add(j("/verify-otp"), view_func=auth_services.verify_otp_handler, methods=["POST"])

--- a/app/config.py
+++ b/app/config.py
@@ -5,6 +5,9 @@ class BaseConfig:
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     CORS_ALLOWED_ORIGINS = os.getenv("CORS_ALLOWED_ORIGINS", "*")
     RATELIMIT_STORAGE_URL = os.getenv("RATELIMIT_STORAGE_URL", "")
+    JWT_SECRET = os.getenv("JWT_SECRET", "dev-insecure-jwt-key")
+    ACCESS_TOKEN_LIFETIME_MIN = int(os.getenv("ACCESS_TOKEN_LIFETIME_MIN", 15))
+    REFRESH_TOKEN_LIFETIME_DAYS = int(os.getenv("REFRESH_TOKEN_LIFETIME_DAYS", 30))
 
 class DevelopmentConfig(BaseConfig):
     DEBUG = True

--- a/helpers/jwt_helpers.py
+++ b/helpers/jwt_helpers.py
@@ -1,0 +1,59 @@
+import datetime as dt
+from typing import Dict
+import jwt
+from flask import current_app
+
+
+def _secret() -> str:
+    return current_app.config["JWT_SECRET"]
+
+
+def _utcnow():
+    return dt.datetime.utcnow()
+
+
+def _exp(minutes: int = None, days: int = None):
+    now = _utcnow()
+    if minutes:
+        return now + dt.timedelta(minutes=minutes)
+    if days:
+        return now + dt.timedelta(days=days)
+    raise ValueError("must supply minutes or days")
+
+
+def create_access_token(phone: str, role: str) -> str:
+    cfg = current_app.config
+    payload: Dict = {
+        "sub": phone,
+        "role": role,
+        "type": "access",
+        "exp": _exp(minutes=cfg["ACCESS_TOKEN_LIFETIME_MIN"])
+    }
+    return jwt.encode(payload, _secret(), algorithm="HS256")
+
+
+def create_refresh_token(phone: str) -> str:
+    cfg = current_app.config
+    payload = {
+        "sub": phone,
+        "type": "refresh",
+        "exp": _exp(days=cfg["REFRESH_TOKEN_LIFETIME_DAYS"])
+    }
+    return jwt.encode(payload, _secret(), algorithm="HS256")
+
+
+class TokenError(Exception):
+    pass
+
+
+def decode_token(token: str, expected_type: str = "access") -> Dict:
+    try:
+        data = jwt.decode(token, _secret(), algorithms=["HS256"])
+    except jwt.ExpiredSignatureError:
+        raise TokenError("token expired")
+    except jwt.InvalidTokenError:
+        raise TokenError("invalid token")
+
+    if data.get("type") != expected_type:
+        raise TokenError(f"expected {expected_type} token")
+    return data

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ psycopg2-binary
 openpyxl
 Flask-Migrate>=4.0.7
 alembic>=1.13.1
+PyJWT>=2.8.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from models import db
 
 @pytest.fixture(scope='session')
 def app_instance():
+    os.environ.setdefault('APP_ENV','testing')
     os.environ.setdefault('DATABASE_URL', 'sqlite:///:memory:')
     os.environ.setdefault('TWILIO_ACCOUNT_SID', 'dummy')
     os.environ.setdefault('TWILIO_AUTH_TOKEN', 'dummy')

--- a/tests/test_cart_order.py
+++ b/tests/test_cart_order.py
@@ -1,5 +1,4 @@
 import pytest
-from models.user import OTP
 from models.shop import Shop
 from models.item import Item
 from models.cart import CartItem
@@ -9,20 +8,9 @@ from models import db
 from app.version import API_PREFIX
 
 
-def send_otp(client, phone):
-    return client.post(f"{API_PREFIX}/send-otp", json={'phone': phone})
-
-
-def verify_otp(client, phone, otp):
-    return client.post(f"{API_PREFIX}/verify-otp", json={'phone': phone, 'otp': otp})
-
-
-def obtain_token(client, app, phone):
-    send_otp(client, phone)
-    with app.app_context():
-        otp_code = OTP.query.filter_by(phone=phone).first().otp
-    resp = verify_otp(client, phone, otp_code)
-    return resp.get_json()['auth_token']
+def obtain_token(client, phone, role="consumer"):
+    resp = client.post("/__auth/login_stub", json={"phone": phone, "role": role})
+    return resp.get_json()["data"]["access"]
 
 
 def onboard_consumer(client, token):
@@ -32,8 +20,8 @@ def onboard_consumer(client, token):
         'society': 'Soc',
         'role': 'consumer'
     }
-    client.post(f"{API_PREFIX}/onboarding/basic", json=basic, headers={'Authorization': token})
-    client.post(f"{API_PREFIX}/onboarding/consumer", json={'flat_number': '1A'}, headers={'Authorization': token})
+    client.post(f"{API_PREFIX}/onboarding/basic", json=basic, headers={'Authorization': f'Bearer {token}'})
+    client.post(f"{API_PREFIX}/onboarding/consumer", json={'flat_number': '1A'}, headers={'Authorization': f'Bearer {token}'})
 
 
 def create_item(app, price=10.0):
@@ -48,18 +36,18 @@ def create_item(app, price=10.0):
 
 
 def add_to_cart_helper(client, token, item_id, qty):
-    return client.post(f"{API_PREFIX}/cart/add", json={'item_id': item_id, 'quantity': qty}, headers={'Authorization': token})
+    return client.post(f"{API_PREFIX}/cart/add", json={'item_id': item_id, 'quantity': qty}, headers={'Authorization': f'Bearer {token}'})
 
 
 def load_wallet(client, token, amount):
-    return client.post(f"{API_PREFIX}/wallet/load", json={'amount': amount}, headers={'Authorization': token})
+    return client.post(f"{API_PREFIX}/wallet/load", json={'amount': amount}, headers={'Authorization': f'Bearer {token}'})
 
 
 # -------------------- Cart Operations --------------------
 
 def test_cart_add_view_update_remove_clear(client, app):
     phone = '9123400000'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     onboard_consumer(client, token)
     item_id, _ = create_item(app)
 
@@ -71,7 +59,7 @@ def test_cart_add_view_update_remove_clear(client, app):
         assert ci and ci.quantity == 2
 
     # view cart
-    view = client.get('/api/v1/cart/view', headers={'Authorization': token})
+    view = client.get('/api/v1/cart/view', headers={'Authorization': f'Bearer {token}'})
     data = view.get_json()
     assert view.status_code == 200
     assert len(data['cart']) == 1
@@ -79,28 +67,28 @@ def test_cart_add_view_update_remove_clear(client, app):
     assert data['cart'][0]['item_id'] == item_id
 
     # update quantity
-    resp = client.post('/api/v1/cart/update', json={'item_id': item_id, 'quantity': 3}, headers={'Authorization': token})
+    resp = client.post('/api/v1/cart/update', json={'item_id': item_id, 'quantity': 3}, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 200
     with app.app_context():
         assert CartItem.query.filter_by(user_phone=phone, item_id=item_id).first().quantity == 3
 
     # remove item
-    resp = client.post('/api/v1/cart/remove', json={'item_id': item_id}, headers={'Authorization': token})
+    resp = client.post('/api/v1/cart/remove', json={'item_id': item_id}, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 200
     with app.app_context():
         assert CartItem.query.filter_by(user_phone=phone).count() == 0
 
     # add again then clear
     add_to_cart_helper(client, token, item_id, 1)
-    resp = client.post('/api/v1/cart/clear', headers={'Authorization': token})
+    resp = client.post('/api/v1/cart/clear', headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 200
-    view = client.get('/api/v1/cart/view', headers={'Authorization': token})
+    view = client.get('/api/v1/cart/view', headers={'Authorization': f'Bearer {token}'})
     assert view.get_json()['cart'] == []
 
 
 def test_cart_add_invalid_item(client, app):
     phone = '9123400001'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     onboard_consumer(client, token)
     # non existing item
     resp = add_to_cart_helper(client, token, 9999, 1)
@@ -109,32 +97,32 @@ def test_cart_add_invalid_item(client, app):
 
 def test_cart_add_missing_fields(client, app):
     phone = '9123400004'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     onboard_consumer(client, token)
     item_id, _ = create_item(app)
 
-    resp = client.post('/api/v1/cart/add', json={'quantity': 1}, headers={'Authorization': token})
+    resp = client.post('/api/v1/cart/add', json={'quantity': 1}, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 404
 
-    resp = client.post('/api/v1/cart/add', json={'item_id': item_id, 'quantity': 0}, headers={'Authorization': token})
+    resp = client.post('/api/v1/cart/add', json={'item_id': item_id, 'quantity': 0}, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 400
 
 
 def test_update_cart_invalid_request(client, app):
     phone = '9123400005'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     onboard_consumer(client, token)
     item_id, _ = create_item(app)
 
     add_to_cart_helper(client, token, item_id, 1)
 
-    resp = client.post('/api/v1/cart/update', json={'item_id': item_id, 'quantity': 0}, headers={'Authorization': token})
+    resp = client.post('/api/v1/cart/update', json={'item_id': item_id, 'quantity': 0}, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 400
 
-    resp = client.post('/api/v1/cart/update', json={'quantity': 2}, headers={'Authorization': token})
+    resp = client.post('/api/v1/cart/update', json={'quantity': 2}, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 400
 
-    resp = client.post('/api/v1/cart/update', json={'item_id': item_id + 1, 'quantity': 2}, headers={'Authorization': token})
+    resp = client.post('/api/v1/cart/update', json={'item_id': item_id + 1, 'quantity': 2}, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 404
 
 
@@ -142,13 +130,13 @@ def test_update_cart_invalid_request(client, app):
 
 def test_confirm_order_wallet_and_cash(client, app):
     phone = '9123400002'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     onboard_consumer(client, token)
     item_id, _ = create_item(app, price=15)
 
     add_to_cart_helper(client, token, item_id, 2)  # total 30
     load_wallet(client, token, 50)
-    resp = client.post('/api/v1/order/confirm', json={'payment_mode': 'wallet'}, headers={'Authorization': token})
+    resp = client.post('/api/v1/order/confirm', json={'payment_mode': 'wallet'}, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 200
     order_id = resp.get_json()['order_id']
     with app.app_context():
@@ -161,11 +149,11 @@ def test_confirm_order_wallet_and_cash(client, app):
         assert OrderItem.query.filter_by(order_id=order_id).count() == 1
         assert WalletTransaction.query.filter_by(user_phone=phone, type='debit').count() == 1
         assert CartItem.query.filter_by(user_phone=phone).count() == 0
-    assert client.get('/api/v1/cart/view', headers={'Authorization': token}).get_json()['cart'] == []
+    assert client.get('/api/v1/cart/view', headers={'Authorization': f'Bearer {token}'}).get_json()['cart'] == []
 
     # cash mode
     add_to_cart_helper(client, token, item_id, 1)
-    resp = client.post('/api/v1/order/confirm', json={'payment_mode': 'cash'}, headers={'Authorization': token})
+    resp = client.post('/api/v1/order/confirm', json={'payment_mode': 'cash'}, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 200
     order_id2 = resp.get_json()['order_id']
     with app.app_context():
@@ -179,16 +167,16 @@ def test_confirm_order_wallet_and_cash(client, app):
 
 def test_confirm_order_errors(client, app):
     phone = '9123400003'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     onboard_consumer(client, token)
     item_id, _ = create_item(app, price=10)
 
     # empty cart
-    resp = client.post('/api/v1/order/confirm', json={'payment_mode': 'cash'}, headers={'Authorization': token})
+    resp = client.post('/api/v1/order/confirm', json={'payment_mode': 'cash'}, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 400
 
     # insufficient wallet balance
     add_to_cart_helper(client, token, item_id, 5)  # total 50
     load_wallet(client, token, 20)
-    resp = client.post('/api/v1/order/confirm', json={'payment_mode': 'wallet'}, headers={'Authorization': token})
+    resp = client.post('/api/v1/order/confirm', json={'payment_mode': 'wallet'}, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 400

--- a/tests/test_jwt_auth.py
+++ b/tests/test_jwt_auth.py
@@ -1,0 +1,51 @@
+import importlib
+import pytest
+import jwt
+import datetime as dt
+from helpers.jwt_helpers import decode_token, create_access_token, create_refresh_token
+
+
+def _load(monkeypatch):
+    monkeypatch.setenv("APP_ENV", "testing")
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "dummy")
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "dummy")
+    monkeypatch.setenv("TWILIO_WHATSAPP_FROM", "dummy")
+    import wsgi as entry
+    importlib.reload(entry)
+    return entry.app
+
+
+def _get_tokens(c, phone="auth1"):
+    r = c.post("/__auth/login_stub", json={"phone": phone, "role": "consumer"})
+    return r.get_json()["data"]
+
+
+def test_access_token_allows_request(monkeypatch):
+    app = _load(monkeypatch)
+    with app.app_context():
+        c = app.test_client()
+        toks = _get_tokens(c)
+        r = c.get("/api/v1/test_support/__ok", headers={"Authorization": f"Bearer {toks['access']}"})
+        assert r.status_code == 200
+
+
+def test_expired_access_token_blocked(monkeypatch):
+    app = _load(monkeypatch)
+    with app.app_context():
+        past = dt.datetime.utcnow() - dt.timedelta(seconds=1)
+        expired = jwt.encode({"sub": "x", "role": "consumer", "type": "access", "exp": past}, app.config["JWT_SECRET"], algorithm="HS256")
+        c = app.test_client()
+        r = c.get("/api/v1/test_support/__ok", headers={"Authorization": f"Bearer {expired}"})
+        assert r.status_code == 401
+
+
+def test_refresh_returns_new_access(monkeypatch):
+    app = _load(monkeypatch)
+    with app.app_context():
+        c = app.test_client()
+        toks = _get_tokens(c, "auth2")
+        r = c.post("/api/v1/auth/refresh", json={"refresh_token": toks["refresh"]})
+        assert r.status_code == 200
+        new_access = r.get_json()["access_token"]
+        r2 = c.get("/api/v1/test_support/__ok", headers={"Authorization": f"Bearer {new_access}"})
+        assert r2.status_code == 200

--- a/tests/test_order_followup.py
+++ b/tests/test_order_followup.py
@@ -1,5 +1,4 @@
 import pytest
-from models.user import OTP
 from models.shop import Shop
 from models.item import Item
 from models.order import Order, OrderItem, OrderStatusLog, OrderActionLog, OrderMessage, OrderRating
@@ -8,35 +7,24 @@ from models import db
 from app.version import API_PREFIX
 
 
-def send_otp(client, phone):
-    return client.post(f"{API_PREFIX}/send-otp", json={'phone': phone})
-
-
-def verify_otp(client, phone, otp):
-    return client.post(f"{API_PREFIX}/verify-otp", json={'phone': phone, 'otp': otp})
-
-
-def obtain_token(client, app, phone):
-    send_otp(client, phone)
-    with app.app_context():
-        otp_code = OTP.query.filter_by(phone=phone).first().otp
-    resp = verify_otp(client, phone, otp_code)
-    return resp.get_json()['auth_token']
+def obtain_token(client, phone, role="consumer"):
+    resp = client.post("/__auth/login_stub", json={"phone": phone, "role": role})
+    return resp.get_json()["data"]["access"]
 
 
 def onboard_consumer(client, token):
     basic = {'name': 'C', 'city': 'Town', 'society': 'Soc', 'role': 'consumer'}
-    client.post(f"{API_PREFIX}/onboarding/basic", json=basic, headers={'Authorization': token})
-    client.post(f"{API_PREFIX}/onboarding/consumer", json={'flat_number': '1A'}, headers={'Authorization': token})
+    client.post(f"{API_PREFIX}/onboarding/basic", json=basic, headers={'Authorization': f'Bearer {token}'})
+    client.post(f"{API_PREFIX}/onboarding/consumer", json={'flat_number': '1A'}, headers={'Authorization': f'Bearer {token}'})
 
 
 def setup_vendor_with_items(client, app, phone):
-    token = obtain_token(client, app, phone)
-    client.post(f"{API_PREFIX}/onboarding/basic", json={'name': 'V', 'city': 'Town', 'society': 'Soc', 'role': 'vendor'}, headers={'Authorization': token})
-    client.post(f"{API_PREFIX}/vendor/profile", json={'business_type': 'retail', 'business_name': 'Shop', 'address': 'Addr'}, headers={'Authorization': token})
-    client.post(f"{API_PREFIX}/vendor/create-shop", json={'shop_name': 'MyShop', 'shop_type': 'grocery'}, headers={'Authorization': token})
-    client.post(f"{API_PREFIX}/item/add", json={'title': 'Item1', 'price': 20}, headers={'Authorization': token})
-    client.post(f"{API_PREFIX}/item/add", json={'title': 'Item2', 'price': 10}, headers={'Authorization': token})
+    token = obtain_token(client, phone, role="vendor")
+    client.post(f"{API_PREFIX}/onboarding/basic", json={'name': 'V', 'city': 'Town', 'society': 'Soc', 'role': 'vendor'}, headers={'Authorization': f'Bearer {token}'})
+    client.post(f"{API_PREFIX}/vendor/profile", json={'business_type': 'retail', 'business_name': 'Shop', 'address': 'Addr'}, headers={'Authorization': f'Bearer {token}'})
+    client.post(f"{API_PREFIX}/vendor/create-shop", json={'shop_name': 'MyShop', 'shop_type': 'grocery'}, headers={'Authorization': f'Bearer {token}'})
+    client.post(f"{API_PREFIX}/item/add", json={'title': 'Item1', 'price': 20}, headers={'Authorization': f'Bearer {token}'})
+    client.post(f"{API_PREFIX}/item/add", json={'title': 'Item2', 'price': 10}, headers={'Authorization': f'Bearer {token}'})
     with app.app_context():
         shop = Shop.query.filter_by(phone=phone).first()
         items = Item.query.filter_by(shop_id=shop.id).all()
@@ -45,23 +33,23 @@ def setup_vendor_with_items(client, app, phone):
 
 
 def add_to_cart(client, token, item_id, qty):
-    return client.post('/api/v1/cart/add', json={'item_id': item_id, 'quantity': qty}, headers={'Authorization': token})
+    return client.post('/api/v1/cart/add', json={'item_id': item_id, 'quantity': qty}, headers={'Authorization': f'Bearer {token}'})
 
 
 def load_wallet(client, token, amount):
-    return client.post('/api/v1/wallet/load', json={'amount': amount}, headers={'Authorization': token})
+    return client.post('/api/v1/wallet/load', json={'amount': amount}, headers={'Authorization': f'Bearer {token}'})
 
 
 def place_order_with_two_items(client, app, suffix="1"):
     vendor_phone = f'900000000{suffix}'
     vendor_token, items = setup_vendor_with_items(client, app, vendor_phone)
     consumer_phone = f'910000000{suffix}'
-    consumer_token = obtain_token(client, app, consumer_phone)
+    consumer_token = obtain_token(client, consumer_phone, role="consumer")
     onboard_consumer(client, consumer_token)
     add_to_cart(client, consumer_token, items[0], 1)
     add_to_cart(client, consumer_token, items[1], 1)
     load_wallet(client, consumer_token, 50)
-    resp = client.post('/api/v1/order/confirm', json={'payment_mode': 'wallet'}, headers={'Authorization': consumer_token})
+    resp = client.post('/api/v1/order/confirm', json={'payment_mode': 'wallet'}, headers={'Authorization': f'Bearer {consumer_token}'})
     order_id = resp.get_json()['order_id']
     return {
         'order_id': order_id,
@@ -85,14 +73,14 @@ def test_confirm_modified_order_with_refund(client, app):
 
     # vendor modifies order - remove second item
     mod = {'modifications': [{'item_id': item_to_remove, 'quantity': 0}]}
-    resp = client.post(f'/api/v1/order/vendor/modify/{order_id}', json=mod, headers={'Authorization': vendor_token})
+    resp = client.post(f'/api/v1/order/vendor/modify/{order_id}', json=mod, headers={'Authorization': f'Bearer {vendor_token}'})
     assert resp.status_code == 200
     with app.app_context():
         order = Order.query.get(order_id)
         assert order.status == 'awaiting_consumer_confirmation'
         assert float(order.final_amount) == 20.0
 
-    resp2 = client.post(f'/api/v1/order/consumer/confirm-modified/{order_id}', headers={'Authorization': consumer_token})
+    resp2 = client.post(f'/api/v1/order/consumer/confirm-modified/{order_id}', headers={'Authorization': f'Bearer {consumer_token}'})
     assert resp2.status_code == 200
     assert resp2.get_json()['refund'] == 10.0
     with app.app_context():
@@ -103,13 +91,13 @@ def test_confirm_modified_order_with_refund(client, app):
         assert OrderActionLog.query.filter_by(order_id=order_id, action_type='modification_confirmed').count() == 1
 
     # wrong state now
-    resp_again = client.post(f'/api/v1/order/consumer/confirm-modified/{order_id}', headers={'Authorization': consumer_token})
+    resp_again = client.post(f'/api/v1/order/consumer/confirm-modified/{order_id}', headers={'Authorization': f'Bearer {consumer_token}'})
     assert resp_again.status_code == 400
 
     # unauthorized user
-    other_token = obtain_token(client, app, '9100000002')
+    other_token = obtain_token(client, '9100000002', role="consumer")
     onboard_consumer(client, other_token)
-    resp_unauth = client.post(f'/api/v1/order/consumer/confirm-modified/{order_id}', headers={'Authorization': other_token})
+    resp_unauth = client.post(f'/api/v1/order/consumer/confirm-modified/{order_id}', headers={'Authorization': f'Bearer {other_token}'})
     assert resp_unauth.status_code == 403
 
 
@@ -132,12 +120,12 @@ def test_cancel_order_consumer_with_wallet_refund(client, app):
         assert message is not None
         assert OrderStatusLog.query.filter_by(order_id=order_id, status='cancelled').count() == 1
 
-    resp_again = client.post(f'/api/v1/order/consumer/cancel/{order_id}', headers={'Authorization': consumer_token})
+    resp_again = client.post(f'/api/v1/order/consumer/cancel/{order_id}', headers={'Authorization': f'Bearer {consumer_token}'})
     assert resp_again.status_code == 400
 
-    other_token = obtain_token(client, app, '9100000003')
+    other_token = obtain_token(client, '9100000003', role="consumer")
     onboard_consumer(client, other_token)
-    resp_unauth = client.post(f'/api/v1/order/consumer/cancel/{order_id}', headers={'Authorization': other_token})
+    resp_unauth = client.post(f'/api/v1/order/consumer/cancel/{order_id}', headers={'Authorization': f'Bearer {other_token}'})
     assert resp_unauth.status_code == 403
 
 
@@ -151,7 +139,7 @@ def test_vendor_modify_order_items(client, app):
     item1, item2 = ctx['item_ids']
 
     mod_payload = {'modifications': [{'item_id': item1, 'quantity': 2}, {'item_id': item2, 'quantity': 0}]}
-    resp = client.post(f'/api/v1/order/vendor/modify/{order_id}', json=mod_payload, headers={'Authorization': vendor_token})
+    resp = client.post(f'/api/v1/order/vendor/modify/{order_id}', json=mod_payload, headers={'Authorization': f'Bearer {vendor_token}'})
     assert resp.status_code == 200
     with app.app_context():
         order = Order.query.get(order_id)
@@ -164,12 +152,12 @@ def test_vendor_modify_order_items(client, app):
 
     # unauthorized vendor
     other_vendor_token, _ = setup_vendor_with_items(client, app, '9000000002')
-    resp_unauth = client.post(f'/api/v1/order/vendor/modify/{order_id}', json=mod_payload, headers={'Authorization': other_vendor_token})
+    resp_unauth = client.post(f'/api/v1/order/vendor/modify/{order_id}', json=mod_payload, headers={'Authorization': f'Bearer {other_vendor_token}'})
     assert resp_unauth.status_code == 403
 
     # modify after cancelling should fail
-    client.post(f'/api/v1/order/vendor/cancel/{order_id}', headers={'Authorization': vendor_token})
-    resp_closed = client.post(f'/api/v1/order/vendor/modify/{order_id}', json=mod_payload, headers={'Authorization': vendor_token})
+    client.post(f'/api/v1/order/vendor/cancel/{order_id}', headers={'Authorization': f'Bearer {vendor_token}'})
+    resp_closed = client.post(f'/api/v1/order/vendor/modify/{order_id}', json=mod_payload, headers={'Authorization': f'Bearer {vendor_token}'})
     assert resp_closed.status_code == 400
 
 
@@ -181,7 +169,7 @@ def test_cancel_order_vendor_refund(client, app):
     vendor_token = ctx['vendor_token']
     consumer_phone = ctx['consumer_phone']
 
-    resp = client.post(f'/api/v1/order/vendor/cancel/{order_id}', headers={'Authorization': vendor_token})
+    resp = client.post(f'/api/v1/order/vendor/cancel/{order_id}', headers={'Authorization': f'Bearer {vendor_token}'})
     assert resp.status_code == 200
     with app.app_context():
         order = Order.query.get(order_id)
@@ -190,11 +178,11 @@ def test_cancel_order_vendor_refund(client, app):
         assert float(wallet.balance) == 50.0
         assert OrderMessage.query.filter_by(order_id=order_id).first() is not None
 
-    resp_again = client.post(f'/api/v1/order/vendor/cancel/{order_id}', headers={'Authorization': vendor_token})
+    resp_again = client.post(f'/api/v1/order/vendor/cancel/{order_id}', headers={'Authorization': f'Bearer {vendor_token}'})
     assert resp_again.status_code == 400
 
     other_vendor_token, _ = setup_vendor_with_items(client, app, '9000000003')
-    resp_unauth = client.post(f'/api/v1/order/vendor/cancel/{order_id}', headers={'Authorization': other_vendor_token})
+    resp_unauth = client.post(f'/api/v1/order/vendor/cancel/{order_id}', headers={'Authorization': f'Bearer {other_vendor_token}'})
     assert resp_unauth.status_code == 403
 
 
@@ -206,9 +194,9 @@ def test_vendor_update_status_and_payout(client, app):
     vendor_token = ctx['vendor_token']
     vendor_phone = ctx['vendor_phone']
 
-    resp = client.post(f'/api/v1/order/vendor/status/{order_id}', json={'status': 'accepted'}, headers={'Authorization': vendor_token})
+    resp = client.post(f'/api/v1/order/vendor/status/{order_id}', json={'status': 'accepted'}, headers={'Authorization': f'Bearer {vendor_token}'})
     assert resp.status_code == 200
-    resp = client.post(f'/api/v1/order/vendor/status/{order_id}', json={'status': 'delivered'}, headers={'Authorization': vendor_token})
+    resp = client.post(f'/api/v1/order/vendor/status/{order_id}', json={'status': 'delivered'}, headers={'Authorization': f'Bearer {vendor_token}'})
     assert resp.status_code == 200
     with app.app_context():
         order = Order.query.get(order_id)
@@ -218,11 +206,11 @@ def test_vendor_update_status_and_payout(client, app):
         assert VendorWalletTransaction.query.filter_by(user_phone=vendor_phone, reference=f'Order #{order_id} delivered').count() == 1
 
     # invalid status
-    resp_bad = client.post(f'/api/v1/order/vendor/status/{order_id}', json={'status': 'unknown'}, headers={'Authorization': vendor_token})
+    resp_bad = client.post(f'/api/v1/order/vendor/status/{order_id}', json={'status': 'unknown'}, headers={'Authorization': f'Bearer {vendor_token}'})
     assert resp_bad.status_code == 400
 
     other_vendor_token, _ = setup_vendor_with_items(client, app, '9000000004')
-    resp_unauth = client.post(f'/api/v1/order/vendor/status/{order_id}', json={'status': 'accepted'}, headers={'Authorization': other_vendor_token})
+    resp_unauth = client.post(f'/api/v1/order/vendor/status/{order_id}', json={'status': 'accepted'}, headers={'Authorization': f'Bearer {other_vendor_token}'})
     assert resp_unauth.status_code == 403
 
 
@@ -240,7 +228,7 @@ def test_consumer_vendor_message_flow(client, app):
     resp = client.post(f'/api/v1/order/consumer/message/send/{order_id}', json={'message': 'Hello'}, headers={'Authorization': consumer_token})
     assert resp.status_code == 200
 
-    resp2 = client.get(f'/api/v1/order/vendor/messages/{order_id}', headers={'Authorization': vendor_token})
+    resp2 = client.get(f'/api/v1/order/vendor/messages/{order_id}', headers={'Authorization': f'Bearer {vendor_token}'})
     assert resp2.status_code == 200
     msgs = resp2.get_json()['messages']
     assert any(m['message'] == 'Hello' for m in msgs)
@@ -254,7 +242,7 @@ def test_rate_order_success_and_errors(client, app):
     consumer_token = ctx['consumer_token']
     vendor_token = ctx['vendor_token']
 
-    client.post(f'/api/v1/order/vendor/status/{order_id}', json={'status': 'delivered'}, headers={'Authorization': vendor_token})
+    client.post(f'/api/v1/order/vendor/status/{order_id}', json={'status': 'delivered'}, headers={'Authorization': f'Bearer {vendor_token}'})
     resp = client.post(f'/api/v1/order/rate/{order_id}', json={'rating': 5, 'review': 'Good'}, headers={'Authorization': consumer_token})
     assert resp.status_code == 200
     with app.app_context():

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,5 +1,5 @@
 import pytest
-from models.user import OTP, UserProfile, ConsumerProfile
+from models.user import UserProfile, ConsumerProfile
 from models import db
 from app.version import API_PREFIX
 
@@ -19,33 +19,30 @@ def do_basic_onboarding(client, token, name='User', city='Town', society='Societ
         'society': society,
         'role': role
     }
-    return client.post(f"{API_PREFIX}/onboarding/basic", json=payload, headers={'Authorization': token})
+    return client.post(f"{API_PREFIX}/onboarding/basic", json=payload, headers={'Authorization': f'Bearer {token}'})
 
 
 def do_consumer_onboarding(client, token, **extra):
-    return client.post(f"{API_PREFIX}/onboarding/consumer", json=extra, headers={'Authorization': token})
+    return client.post(f"{API_PREFIX}/onboarding/consumer", json=extra, headers={'Authorization': f'Bearer {token}'})
 
 
 def get_profile(client, token):
-    return client.get(f"{API_PREFIX}/profile/me", headers={'Authorization': token})
+    return client.get(f"{API_PREFIX}/profile/me", headers={'Authorization': f'Bearer {token}'})
 
 
 def edit_profile(client, token, data):
-    return client.post(f"{API_PREFIX}/profile/edit", json=data, headers={'Authorization': token})
+    return client.post(f"{API_PREFIX}/profile/edit", json=data, headers={'Authorization': f'Bearer {token}'})
 
 
 
-def obtain_token(client, app, phone):
-    send_otp(client, phone)
-    with app.app_context():
-        otp_code = OTP.query.filter_by(phone=phone).first().otp
-    resp = verify_otp(client, phone, otp_code)
-    return resp.get_json()['auth_token']
+def obtain_token(client, phone):
+    resp = client.post("/__auth/login_stub", json={"phone": phone, "role": "consumer"})
+    return resp.get_json()["data"]["access"]
 
 
 def test_basic_onboarding_success(client, app):
     phone = '9900011111'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     resp = do_basic_onboarding(client, token, name='Alice', city='Delhi', society='Blue', role='consumer')
     assert resp.status_code == 200
     with app.app_context():
@@ -59,15 +56,15 @@ def test_basic_onboarding_success(client, app):
 
 def test_basic_onboarding_missing_fields(client, app):
     phone = '9900022222'
-    token = obtain_token(client, app, phone)
-    resp = client.post('/api/v1/onboarding/basic', json={'name': 'Bob'}, headers={'Authorization': token})
+    token = obtain_token(client, phone)
+    resp = client.post('/api/v1/onboarding/basic', json={'name': 'Bob'}, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 400
     assert resp.get_json()['message'] == 'Missing fields'
 
 
 def test_basic_onboarding_already_onboarded(client, app):
     phone = '9900033333'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     assert do_basic_onboarding(client, token).status_code == 200
     resp_again = do_basic_onboarding(client, token)
     assert resp_again.status_code == 400
@@ -76,7 +73,7 @@ def test_basic_onboarding_already_onboarded(client, app):
 
 def test_consumer_onboarding_success(client, app):
     phone = '9900044444'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     do_basic_onboarding(client, token, role='consumer')
     resp = do_consumer_onboarding(client, token, flat_number='A1', preferred_language='en')
     assert resp.status_code == 200
@@ -91,7 +88,7 @@ def test_consumer_onboarding_success(client, app):
 
 def test_consumer_onboarding_without_basic(client, app):
     phone = '9900055555'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     # Assign a role so role_required passes but basic onboarding flag remains False
     with app.app_context():
         user = UserProfile.query.filter_by(phone=phone).first()
@@ -107,7 +104,7 @@ def test_consumer_onboarding_without_basic(client, app):
 
 def test_consumer_onboarding_already_done(client, app):
     phone = '9900066666'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     do_basic_onboarding(client, token)
     assert do_consumer_onboarding(client, token).status_code == 200
     resp_again = do_consumer_onboarding(client, token)
@@ -117,7 +114,7 @@ def test_consumer_onboarding_already_done(client, app):
 
 def test_get_and_edit_consumer_profile(client, app):
     phone = '9900077777'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     do_basic_onboarding(client, token)
     do_consumer_onboarding(client, token, flat_number='101', preferred_language='en')
 

--- a/tests/test_vendor.py
+++ b/tests/test_vendor.py
@@ -1,24 +1,13 @@
 import pytest
-from models.user import OTP, UserProfile
+from models.user import UserProfile
 from models.vendor import VendorProfile, VendorDocument, VendorPayoutBank
 from models import db
 from app.version import API_PREFIX
 
 
-def send_otp(client, phone):
-    return client.post(f"{API_PREFIX}/send-otp", json={'phone': phone})
-
-
-def verify_otp(client, phone, otp):
-    return client.post(f"{API_PREFIX}/verify-otp", json={'phone': phone, 'otp': otp})
-
-
-def obtain_token(client, app, phone):
-    send_otp(client, phone)
-    with app.app_context():
-        otp_code = OTP.query.filter_by(phone=phone).first().otp
-    resp = verify_otp(client, phone, otp_code)
-    return resp.get_json()['auth_token']
+def obtain_token(client, phone):
+    resp = client.post("/__auth/login_stub", json={"phone": phone, "role": "vendor"})
+    return resp.get_json()["data"]["access"]
 
 
 def do_basic_onboarding(client, token, role='vendor'):
@@ -28,12 +17,12 @@ def do_basic_onboarding(client, token, role='vendor'):
         'society': 'Society',
         'role': role
     }
-    return client.post(f"{API_PREFIX}/onboarding/basic", json=payload, headers={'Authorization': token})
+    return client.post(f"{API_PREFIX}/onboarding/basic", json=payload, headers={'Authorization': f'Bearer {token}'})
 
 
 def test_vendor_profile_setup_success(client, app):
     phone = '8000000001'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     do_basic_onboarding(client, token, role='vendor')
 
     payload = {
@@ -42,7 +31,7 @@ def test_vendor_profile_setup_success(client, app):
         'gst_number': 'GST123',
         'address': '123 Market'
     }
-    resp = client.post('/api/v1/vendor/profile', json=payload, headers={'Authorization': token})
+    resp = client.post('/api/v1/vendor/profile', json=payload, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 200
     with app.app_context():
         profile = VendorProfile.query.filter_by(user_phone=phone).first()
@@ -54,23 +43,23 @@ def test_vendor_profile_setup_success(client, app):
 
 def test_vendor_profile_requires_basic_onboarding(client, app):
     phone = '8000000002'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     with app.app_context():
         user = UserProfile.query.filter_by(phone=phone).first()
         user.role = 'vendor'
         db.session.commit()
 
-    resp = client.post('/api/v1/vendor/profile', json={'business_type': 'retail', 'business_name': 'Test', 'address': 'Addr'}, headers={'Authorization': token})
+    resp = client.post('/api/v1/vendor/profile', json={'business_type': 'retail', 'business_name': 'Test', 'address': 'Addr'}, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 400
     assert resp.get_json()['message'] == 'Basic onboarding incomplete'
 
 
 def test_vendor_profile_missing_fields_and_duplicate(client, app):
     phone = '8000000003'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     do_basic_onboarding(client, token, role='vendor')
     # Missing fields
-    resp = client.post('/api/v1/vendor/profile', json={'business_name': 'A'}, headers={'Authorization': token})
+    resp = client.post('/api/v1/vendor/profile', json={'business_name': 'A'}, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 400
     assert resp.get_json()['message'] == 'Missing required vendor details'
 
@@ -80,37 +69,37 @@ def test_vendor_profile_missing_fields_and_duplicate(client, app):
         'business_name': 'Shop',
         'address': 'Addr'
     }
-    assert client.post('/api/v1/vendor/profile', json=payload, headers={'Authorization': token}).status_code == 200
+    assert client.post('/api/v1/vendor/profile', json=payload, headers={'Authorization': f'Bearer {token}'}).status_code == 200
     # Second attempt should fail
-    resp_again = client.post('/api/v1/vendor/profile', json=payload, headers={'Authorization': token})
+    resp_again = client.post('/api/v1/vendor/profile', json=payload, headers={'Authorization': f'Bearer {token}'})
     assert resp_again.status_code == 400
     assert resp_again.get_json()['message'] == 'Vendor profile already exists'
 
 
 def test_upload_vendor_document(client, app):
     phone = '8000000004'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     do_basic_onboarding(client, token, role='vendor')
-    client.post('/api/v1/vendor/profile', json={'business_type': 'retail', 'business_name': 'Shop', 'address': 'Addr'}, headers={'Authorization': token})
+    client.post('/api/v1/vendor/profile', json={'business_type': 'retail', 'business_name': 'Shop', 'address': 'Addr'}, headers={'Authorization': f'Bearer {token}'})
 
-    resp = client.post('/api/v1/vendor/upload-document', json={'document_type': 'aadhaar', 'file_url': 'http://file'}, headers={'Authorization': token})
+    resp = client.post('/api/v1/vendor/upload-document', json={'document_type': 'aadhaar', 'file_url': 'http://file'}, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 200
     with app.app_context():
         doc = VendorDocument.query.filter_by(vendor_phone=phone, document_type='aadhaar').first()
         assert doc is not None
 
-    resp_fail = client.post('/api/v1/vendor/upload-document', json={'document_type': 'aadhaar'}, headers={'Authorization': token})
+    resp_fail = client.post('/api/v1/vendor/upload-document', json={'document_type': 'aadhaar'}, headers={'Authorization': f'Bearer {token}'})
     assert resp_fail.status_code == 400
 
 
 def test_setup_payout_bank_create_and_update(client, app):
     phone = '8000000005'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     do_basic_onboarding(client, token, role='vendor')
-    client.post('/api/v1/vendor/profile', json={'business_type': 'retail', 'business_name': 'Shop', 'address': 'Addr'}, headers={'Authorization': token})
+    client.post('/api/v1/vendor/profile', json={'business_type': 'retail', 'business_name': 'Shop', 'address': 'Addr'}, headers={'Authorization': f'Bearer {token}'})
 
     data1 = {'bank_name': 'BankA', 'account_number': '111', 'ifsc_code': 'IFSC1'}
-    resp1 = client.post('/api/v1/vendor/payout/setup', json=data1, headers={'Authorization': token})
+    resp1 = client.post('/api/v1/vendor/payout/setup', json=data1, headers={'Authorization': f'Bearer {token}'})
     assert resp1.status_code == 200
     with app.app_context():
         bank = VendorPayoutBank.query.filter_by(user_phone=phone).first()
@@ -118,7 +107,7 @@ def test_setup_payout_bank_create_and_update(client, app):
         assert bank.bank_name == 'BankA'
 
     data2 = {'bank_name': 'BankB', 'account_number': '222', 'ifsc_code': 'IFSC2'}
-    resp2 = client.post('/api/v1/vendor/payout/setup', json=data2, headers={'Authorization': token})
+    resp2 = client.post('/api/v1/vendor/payout/setup', json=data2, headers={'Authorization': f'Bearer {token}'})
     assert resp2.status_code == 200
     with app.app_context():
         banks = VendorPayoutBank.query.filter_by(user_phone=phone).all()
@@ -126,5 +115,5 @@ def test_setup_payout_bank_create_and_update(client, app):
         assert banks[0].bank_name == 'BankB'
         assert banks[0].account_number == '222'
 
-    resp_fail = client.post('/api/v1/vendor/payout/setup', json={'bank_name': 'BankX'}, headers={'Authorization': token})
+    resp_fail = client.post('/api/v1/vendor/payout/setup', json={'bank_name': 'BankX'}, headers={'Authorization': f'Bearer {token}'})
     assert resp_fail.status_code == 400

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -1,52 +1,40 @@
 import pytest
-from models.user import OTP
 from models.wallet import ConsumerWallet, WalletTransaction, VendorWallet, VendorWalletTransaction
 from models.vendor import VendorPayoutBank
 from models import db
 from app.version import API_PREFIX
 
 
-def send_otp(client, phone):
-    return client.post(f"{API_PREFIX}/send-otp", json={'phone': phone})
-
-
-def verify_otp(client, phone, otp):
-    return client.post(f"{API_PREFIX}/verify-otp", json={'phone': phone, 'otp': otp})
-
-
-def obtain_token(client, app, phone):
-    send_otp(client, phone)
-    with app.app_context():
-        otp_code = OTP.query.filter_by(phone=phone).first().otp
-    resp = verify_otp(client, phone, otp_code)
-    return resp.get_json()['auth_token']
+def obtain_token(client, phone, role="consumer"):
+    resp = client.post("/__auth/login_stub", json={"phone": phone, "role": role})
+    return resp.get_json()["data"]["access"]
 
 
 def onboard_consumer(client, token):
     basic = {'name': 'C', 'city': 'Town', 'society': 'Soc', 'role': 'consumer'}
-    client.post(f"{API_PREFIX}/onboarding/basic", json=basic, headers={'Authorization': token})
-    client.post(f"{API_PREFIX}/onboarding/consumer", json={'flat_number': '1A'}, headers={'Authorization': token})
+    client.post(f"{API_PREFIX}/onboarding/basic", json=basic, headers={'Authorization': f'Bearer {token}'})
+    client.post(f"{API_PREFIX}/onboarding/consumer", json={'flat_number': '1A'}, headers={'Authorization': f'Bearer {token}'})
 
 
 def onboard_vendor(client, token):
     basic = {'name': 'V', 'city': 'Town', 'society': 'Soc', 'role': 'vendor'}
-    client.post(f"{API_PREFIX}/onboarding/basic", json=basic, headers={'Authorization': token})
+    client.post(f"{API_PREFIX}/onboarding/basic", json=basic, headers={'Authorization': f'Bearer {token}'})
 
 
 
 def setup_payout_bank(client, token):
     data = {'bank_name': 'BankA', 'account_number': '123456', 'ifsc_code': 'IFSC0'}
-    return client.post(f"{API_PREFIX}/vendor/payout/setup", json=data, headers={'Authorization': token})
+    return client.post(f"{API_PREFIX}/vendor/payout/setup", json=data, headers={'Authorization': f'Bearer {token}'})
 
 
 # ---------------------- Consumer Wallet ----------------------
 
 def test_get_or_create_wallet(client, app):
     phone = '7000000001'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     onboard_consumer(client, token)
 
-    resp = client.get('/api/v1/wallet', headers={'Authorization': token})
+    resp = client.get('/api/v1/wallet', headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 200
     assert resp.get_json()['balance'] == 0.0
     with app.app_context():
@@ -54,7 +42,7 @@ def test_get_or_create_wallet(client, app):
         assert wallet is not None
         assert float(wallet.balance) == 0.0
 
-    resp2 = client.get('/api/v1/wallet', headers={'Authorization': token})
+    resp2 = client.get('/api/v1/wallet', headers={'Authorization': f'Bearer {token}'})
     assert resp2.status_code == 200
     assert resp2.get_json()['balance'] == 0.0
     with app.app_context():
@@ -63,10 +51,10 @@ def test_get_or_create_wallet(client, app):
 
 def test_load_wallet_success_and_invalid_amount(client, app):
     phone = '7000000002'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     onboard_consumer(client, token)
 
-    resp = client.post('/api/v1/wallet/load', json={'amount': 500}, headers={'Authorization': token})
+    resp = client.post('/api/v1/wallet/load', json={'amount': 500}, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 200
     assert resp.get_json()['balance'] == 500.0
     with app.app_context():
@@ -75,7 +63,7 @@ def test_load_wallet_success_and_invalid_amount(client, app):
         txn = WalletTransaction.query.filter_by(user_phone=phone, type='recharge').first()
         assert txn and float(txn.amount) == 500.0
 
-    resp_bad = client.post('/api/v1/wallet/load', json={'amount': 0}, headers={'Authorization': token})
+    resp_bad = client.post('/api/v1/wallet/load', json={'amount': 0}, headers={'Authorization': f'Bearer {token}'})
     assert resp_bad.status_code == 400
     assert resp_bad.get_json()['message'] == 'Invalid amount'
     with app.app_context():
@@ -85,11 +73,11 @@ def test_load_wallet_success_and_invalid_amount(client, app):
 
 def test_debit_wallet_success_and_insufficient(client, app):
     phone = '7000000003'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     onboard_consumer(client, token)
-    client.post('/api/v1/wallet/load', json={'amount': 300}, headers={'Authorization': token})
+    client.post('/api/v1/wallet/load', json={'amount': 300}, headers={'Authorization': f'Bearer {token}'})
 
-    resp = client.post('/api/v1/wallet/debit', json={'amount': 100}, headers={'Authorization': token})
+    resp = client.post('/api/v1/wallet/debit', json={'amount': 100}, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 200
     assert resp.get_json()['balance'] == 200.0
     with app.app_context():
@@ -97,7 +85,7 @@ def test_debit_wallet_success_and_insufficient(client, app):
         assert float(wallet.balance) == 200.0
         assert WalletTransaction.query.filter_by(user_phone=phone, type='debit').count() == 1
 
-    resp_bad = client.post('/api/v1/wallet/debit', json={'amount': 400}, headers={'Authorization': token})
+    resp_bad = client.post('/api/v1/wallet/debit', json={'amount': 400}, headers={'Authorization': f'Bearer {token}'})
     assert resp_bad.status_code == 400
     assert resp_bad.get_json()['message'] == 'Insufficient balance'
     with app.app_context():
@@ -106,19 +94,19 @@ def test_debit_wallet_success_and_insufficient(client, app):
 
     # when wallet doesn't exist
     phone2 = '7000000004'
-    token2 = obtain_token(client, app, phone2)
+    token2 = obtain_token(client, phone2)
     onboard_consumer(client, token2)
-    resp_none = client.post('/api/v1/wallet/debit', json={'amount': 50}, headers={'Authorization': token2})
+    resp_none = client.post('/api/v1/wallet/debit', json={'amount': 50}, headers={'Authorization': f'Bearer {token2}'})
     assert resp_none.status_code == 400
     assert resp_none.get_json()['message'] == 'Insufficient balance'
 
 
 def test_refund_wallet_creates_wallet(client, app):
     phone = '7000000005'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     onboard_consumer(client, token)
 
-    resp = client.post('/api/v1/wallet/refund', json={'amount': 120}, headers={'Authorization': token})
+    resp = client.post('/api/v1/wallet/refund', json={'amount': 120}, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 200
     assert resp.get_json()['balance'] == 120.0
     with app.app_context():
@@ -130,14 +118,14 @@ def test_refund_wallet_creates_wallet(client, app):
 
 def test_wallet_transaction_history(client, app):
     phone = '7000000006'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     onboard_consumer(client, token)
 
-    client.post('/api/v1/wallet/load', json={'amount': 50}, headers={'Authorization': token})
-    client.post('/api/v1/wallet/debit', json={'amount': 20}, headers={'Authorization': token})
-    client.post('/api/v1/wallet/refund', json={'amount': 10}, headers={'Authorization': token})
+    client.post('/api/v1/wallet/load', json={'amount': 50}, headers={'Authorization': f'Bearer {token}'})
+    client.post('/api/v1/wallet/debit', json={'amount': 20}, headers={'Authorization': f'Bearer {token}'})
+    client.post('/api/v1/wallet/refund', json={'amount': 10}, headers={'Authorization': f'Bearer {token}'})
 
-    resp = client.get('/api/v1/wallet/history', headers={'Authorization': token})
+    resp = client.get('/api/v1/wallet/history', headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 200
     data = resp.get_json()['transactions']
     assert len(data) == 3
@@ -149,17 +137,17 @@ def test_wallet_transaction_history(client, app):
 
 def test_get_vendor_wallet_and_creation(client, app):
     phone = '7100000001'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     onboard_vendor(client, token)
 
-    resp = client.get('/api/v1/vendor/wallet', headers={'Authorization': token})
+    resp = client.get('/api/v1/vendor/wallet', headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 200
     assert resp.get_json()['balance'] == 0.0
     with app.app_context():
         wallet = VendorWallet.query.filter_by(user_phone=phone).first()
         assert wallet and float(wallet.balance) == 0.0
 
-    resp2 = client.get('/api/v1/vendor/wallet', headers={'Authorization': token})
+    resp2 = client.get('/api/v1/vendor/wallet', headers={'Authorization': f'Bearer {token}'})
     assert resp2.status_code == 200
     with app.app_context():
         assert VendorWallet.query.filter_by(user_phone=phone).count() == 1
@@ -167,10 +155,10 @@ def test_get_vendor_wallet_and_creation(client, app):
 
 def test_credit_vendor_wallet_and_invalid_amount(client, app):
     phone = '7100000002'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     onboard_vendor(client, token)
 
-    resp = client.post('/api/v1/vendor/wallet/credit', json={'amount': 100}, headers={'Authorization': token})
+    resp = client.post('/api/v1/vendor/wallet/credit', json={'amount': 100}, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 200
     assert resp.get_json()['balance'] == 100.0
     with app.app_context():
@@ -179,7 +167,7 @@ def test_credit_vendor_wallet_and_invalid_amount(client, app):
         txn = VendorWalletTransaction.query.filter_by(user_phone=phone, type='credit').first()
         assert txn and float(txn.amount) == 100.0
 
-    bad = client.post('/api/v1/vendor/wallet/credit', json={'amount': 0}, headers={'Authorization': token})
+    bad = client.post('/api/v1/vendor/wallet/credit', json={'amount': 0}, headers={'Authorization': f'Bearer {token}'})
     assert bad.status_code == 400
     assert bad.get_json()['message'] == 'Invalid credit amount'
     with app.app_context():
@@ -189,11 +177,11 @@ def test_credit_vendor_wallet_and_invalid_amount(client, app):
 
 def test_debit_vendor_wallet_success_and_insufficient(client, app):
     phone = '7100000003'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     onboard_vendor(client, token)
-    client.post('/api/v1/vendor/wallet/credit', json={'amount': 100}, headers={'Authorization': token})
+    client.post('/api/v1/vendor/wallet/credit', json={'amount': 100}, headers={'Authorization': f'Bearer {token}'})
 
-    resp = client.post('/api/v1/vendor/wallet/debit', json={'amount': 30}, headers={'Authorization': token})
+    resp = client.post('/api/v1/vendor/wallet/debit', json={'amount': 30}, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 200
     assert resp.get_json()['balance'] == 70.0
     with app.app_context():
@@ -201,7 +189,7 @@ def test_debit_vendor_wallet_success_and_insufficient(client, app):
         assert float(wallet.balance) == 70.0
         assert VendorWalletTransaction.query.filter_by(user_phone=phone, type='debit').count() == 1
 
-    resp_bad = client.post('/api/v1/vendor/wallet/debit', json={'amount': 200}, headers={'Authorization': token})
+    resp_bad = client.post('/api/v1/vendor/wallet/debit', json={'amount': 200}, headers={'Authorization': f'Bearer {token}'})
     assert resp_bad.status_code == 400
     assert resp_bad.get_json()['message'] == 'Insufficient balance'
 
@@ -211,9 +199,9 @@ def test_withdraw_vendor_wallet(client, app):
     token = obtain_token(client, app, phone)
     onboard_vendor(client, token)
     setup_payout_bank(client, token)
-    client.post('/api/v1/vendor/wallet/credit', json={'amount': 100}, headers={'Authorization': token})
+    client.post('/api/v1/vendor/wallet/credit', json={'amount': 100}, headers={'Authorization': f'Bearer {token}'})
 
-    resp = client.post('/api/v1/vendor/wallet/withdraw', json={'amount': 60}, headers={'Authorization': token})
+    resp = client.post('/api/v1/vendor/wallet/withdraw', json={'amount': 60}, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 200
     data = resp.get_json()
     assert data['balance'] == 40.0
@@ -224,29 +212,29 @@ def test_withdraw_vendor_wallet(client, app):
         txn = VendorWalletTransaction.query.filter_by(user_phone=phone, type='withdrawal').first()
         assert txn and float(txn.amount) == 60.0
 
-    resp_bad = client.post('/api/v1/vendor/wallet/withdraw', json={'amount': 100}, headers={'Authorization': token})
+    resp_bad = client.post('/api/v1/vendor/wallet/withdraw', json={'amount': 100}, headers={'Authorization': f'Bearer {token}'})
     assert resp_bad.status_code == 400
     assert resp_bad.get_json()['message'] == 'Insufficient balance'
 
     # No bank info scenario
     phone2 = '7100000005'
-    token2 = obtain_token(client, app, phone2)
+    token2 = obtain_token(client, phone2)
     onboard_vendor(client, token2)
-    client.post('/api/v1/vendor/wallet/credit', json={'amount': 20}, headers={'Authorization': token2})
-    fail_no_bank = client.post('/api/v1/vendor/wallet/withdraw', json={'amount': 10}, headers={'Authorization': token2})
+    client.post('/api/v1/vendor/wallet/credit', json={'amount': 20}, headers={'Authorization': f'Bearer {token2}'})
+    fail_no_bank = client.post('/api/v1/vendor/wallet/withdraw', json={'amount': 10}, headers={'Authorization': f'Bearer {token2}'})
     assert fail_no_bank.status_code == 400
     assert fail_no_bank.get_json()['message'] == 'No payout bank setup found'
 
 
 def test_vendor_wallet_history(client, app):
     phone = '7100000006'
-    token = obtain_token(client, app, phone)
+    token = obtain_token(client, phone)
     onboard_vendor(client, token)
 
-    client.post('/api/v1/vendor/wallet/credit', json={'amount': 40}, headers={'Authorization': token})
-    client.post('/api/v1/vendor/wallet/debit', json={'amount': 10}, headers={'Authorization': token})
+    client.post('/api/v1/vendor/wallet/credit', json={'amount': 40}, headers={'Authorization': f'Bearer {token}'})
+    client.post('/api/v1/vendor/wallet/debit', json={'amount': 10}, headers={'Authorization': f'Bearer {token}'})
 
-    resp = client.get('/api/v1/vendor/wallet/history', headers={'Authorization': token})
+    resp = client.get('/api/v1/vendor/wallet/history', headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 200
     data = resp.get_json()['transactions']
     assert len(data) == 2

--- a/utils/auth_decorator.py
+++ b/utils/auth_decorator.py
@@ -1,25 +1,31 @@
-from flask import request, jsonify
-from models.user import UserProfile
-from datetime import datetime, timedelta
 from functools import wraps
+from flask import request, jsonify, g
+from utils.role_decorator import role_required  # keep role decorator unchanged
+from helpers.jwt_helpers import decode_token, TokenError
+from models.user import UserProfile
 
-def auth_required(f):
-    @wraps(f)
-    def decorated_function(*args, **kwargs):
-        token = request.headers.get("Authorization")
-        if not token:
-            return jsonify({"status": "error", "message": "Token missing"}), 401
 
-        user = UserProfile.query.filter_by(auth_token=token).first()
-        if not user:
-            return jsonify({"status": "error", "message": "Invalid token"}), 401
+def auth_required(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        auth = request.headers.get("Authorization", "")
+        if not auth.startswith("Bearer "):
+            return jsonify({"status": "error", "message": "Auth header missing"}), 401
+        token = auth.split(" ", 1)[1]
+        try:
+            payload = decode_token(token, expected_type="access")
+        except TokenError as e:
+            return jsonify({"status": "error", "message": str(e)}), 401
 
-        if user.token_created_at and datetime.utcnow() - user.token_created_at > timedelta(days=30):
-            return jsonify({"status": "error", "message": "Token expired"}), 401
+        # Expose user info to downstream handlers
+        g.phone = payload["sub"]
+        g.role = payload.get("role")
+        request.phone = g.phone  # maintain backward compat
+        user = UserProfile.query.filter_by(phone=g.phone).first()
+        if user:
+            request.user = user
+        else:
+            request.user = type("User", (), {"phone": g.phone, "role": g.role})
+        return func(*args, **kwargs)
 
-        request.phone = user.phone
-        request.user = user
-        request.user_role = user.role
-        return f(*args, **kwargs)
-
-    return decorated_function
+    return wrapper

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,1 @@
+from main import app


### PR DESCRIPTION
## Summary
- add jwt helpers and auth decorator overhaul
- issue JWT access/refresh tokens during login
- add token refresh route and login stub for testing
- rewrite tests to use Bearer tokens
- add wsgi entrypoint and update configs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: dotenv, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6887bedaaa1c83338f38e50d51aa4438