### PR TITLE
Fix circular import in auth service

### DIFF
--- a/extensions.py
+++ b/extensions.py
@@ -1,0 +1,10 @@
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+import os
+
+limiter = Limiter(
+    key_func=get_remote_address,
+    storage_uri=os.getenv("RATELIMIT_STORAGE_URL", "memory://"),
+    strategy="fixed-window",
+    default_limits=["200 per hour"],
+)

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from flask import Flask
 from models import db
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
+import extensions
 from flasgger import Swagger
 from prometheus_flask_exporter import PrometheusMetrics
 # from agent.query_handler import ask_agent_handler
@@ -33,6 +34,7 @@ limiter = Limiter(
     strategy="fixed-window",
     default_limits=["200 per hour"],
 )
+extensions.limiter = limiter
 app.limiter = limiter
 from models import user, vendor, shop, item, order, wallet, cart  # noqa: F401
 migrate = Migrate(app, db, compare_type=True, render_as_batch=True)

--- a/services/auth.py
+++ b/services/auth.py
@@ -1,6 +1,6 @@
 from flask import request, jsonify, current_app, Blueprint
 from flask_limiter.util import get_remote_address
-from main import limiter, app
+from extensions import limiter
 from models.user import OTP, UserProfile
 from models import db
 import random
@@ -86,12 +86,12 @@ def send_whatsapp_message(to, body):
 # --- Send OTP ---
 
 @limiter.limit(
-    app.config["OTP_SEND_LIMIT_PER_IP"],
+    lambda: current_app.config["OTP_SEND_LIMIT_PER_IP"],
     key_func=get_remote_address,
     error_message="Too many OTP requests from this IP",
 )
 @limiter.limit(
-    app.config["OTP_SEND_LIMIT_PER_PHONE"],
+    lambda: current_app.config["OTP_SEND_LIMIT_PER_PHONE"],
     key_func=lambda: (request.get_json() or {}).get("phone", ""),
     error_message="Too many OTP requests for this phone number",
 )
@@ -129,7 +129,7 @@ def send_otp_handler():
 # --- Verify OTP ---
 
 @limiter.limit(
-    app.config["LOGIN_LIMIT_PER_IP"],
+    lambda: current_app.config["LOGIN_LIMIT_PER_IP"],
     key_func=get_remote_address,
     error_message="Too many logins from this IP",
 )


### PR DESCRIPTION
## Summary
- expose shared limiter via `extensions` module
- configure limiter in `main` and reference from services
- use `current_app` in limiter decorators to avoid circular imports

## Testing
- `pytest -q`
- `python main.py` *(fails: Twilio credentials missing)*

------
https://chatgpt.com/codex/tasks/task_e_6888a34840dc833382a79d85d75e7a71