### PR TITLE
Add optional AI agent endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,7 @@ Basic admin endpoints protected by JWT auth and `admin` role:
 - `GET /api/v1/admin/users` - List recent users
 - `GET /api/v1/admin/shops` - List recent shops
 - `GET /api/v1/admin/orders` - List recent orders
+
+### Optional AI assistant
+
+If `OPENAI_API_KEY` is provided in the environment, the service exposes `/api/v1/agent/query` for chat-based assistance. The endpoint requires authentication and returns the assistant's answer along with suggestions.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -33,6 +33,16 @@ def create_app(config_object=None):
     configure_logging(app)
     register_cli(app)
 
+    # Optional OpenAI configuration for the assistant
+    openai_key = os.environ.get("OPENAI_API_KEY")
+    if openai_key:
+        try:
+            import openai
+            openai.api_key = openai_key
+            app.logger.info("OpenAI integration enabled")
+        except Exception as e:  # pragma: no cover - runtime configuration
+            app.logger.error("OpenAI init failed: %s", e)
+
     # Initialize extensions
     limiter = extensions.limiter
     limiter.init_app(app)

--- a/app/api.py
+++ b/app/api.py
@@ -8,7 +8,10 @@ from app.routes import (
     wallet_bp,
     order_bp,
     admin_bp,
+    agent_bp,
 )
+import os
+import logging
 
 
 def register_api_v1(app):
@@ -22,4 +25,9 @@ def register_api_v1(app):
     app.register_blueprint(wallet_bp)
     app.register_blueprint(order_bp)
     app.register_blueprint(admin_bp)
+    if os.environ.get("OPENAI_API_KEY") and agent_bp:
+        logging.info("Agent blueprint enabled")
+        app.register_blueprint(agent_bp)
+    else:
+        logging.info("Agent blueprint not enabled")
 

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -7,6 +7,11 @@ from .cart import cart_bp
 from .wallet import wallet_bp
 from .order import order_bp
 from .admin import admin_bp
+try:
+    from .agent import agent_bp
+except Exception:  # pragma: no cover - agent optional
+    agent_bp = None
+
 
 __all__ = [
     'auth_bp',
@@ -18,4 +23,5 @@ __all__ = [
     'wallet_bp',
     'order_bp',
     'admin_bp',
+    'agent_bp',
 ]

--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -1,0 +1,24 @@
+from flask import Blueprint, request, jsonify
+from app.utils import auth_required
+from agent.agent_core import run_agent
+
+# Optional blueprint for AI assistant
+agent_bp = Blueprint('agent', __name__, url_prefix='/api/v1/agent')
+
+@agent_bp.route('/query', methods=['POST'])
+@auth_required
+def agent_query():
+    """Handle AI assistant queries."""
+    user_query = request.json.get('query') if request.is_json else None
+    if not user_query:
+        return jsonify({'status': 'error', 'message': 'Query is required'}), 400
+
+    user_info = {
+        'phone': getattr(request, 'phone', None),
+        'user_role': getattr(request, 'user_role', None),
+    }
+    try:
+        answer, suggestions = run_agent(user_query, user_info)
+        return jsonify({'status': 'success', 'answer': answer, 'suggestions': suggestions})
+    except Exception as e:
+        return jsonify({'status': 'error', 'message': str(e)}), 500


### PR DESCRIPTION
## Summary
- support optional assistant blueprint when `OPENAI_API_KEY` is set
- register the blueprint conditionally
- configure OpenAI in the application factory
- expose `/api/v1/agent/query` route guarded by auth
- document optional agent endpoint in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f6f2dde883339d0f001db77298bb