### PR TITLE
Improve prod readiness

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -12,6 +12,9 @@ class BaseConfig:
     JWT_SECRET = os.getenv("JWT_SECRET", "dev-insecure-jwt-key")
     ACCESS_TOKEN_LIFETIME_MIN = int(os.getenv("ACCESS_TOKEN_LIFETIME_MIN", 15))
     REFRESH_TOKEN_LIFETIME_DAYS = int(os.getenv("REFRESH_TOKEN_LIFETIME_DAYS", 30))
+    TWILIO_ACCOUNT_SID = os.getenv("TWILIO_ACCOUNT_SID")
+    TWILIO_AUTH_TOKEN = os.getenv("TWILIO_AUTH_TOKEN")
+    TWILIO_WHATSAPP_FROM = os.getenv("TWILIO_WHATSAPP_FROM")
 
 class DevelopmentConfig(BaseConfig):
     DEBUG = True

--- a/app/logging.py
+++ b/app/logging.py
@@ -28,15 +28,16 @@ def configure_logging(app):
 
     app.logger.handlers.clear()
     app.logger.addHandler(handler)
-    app.logger.setLevel(logging.INFO)
+    level = logging.DEBUG if app.config.get("DEBUG") else logging.INFO
+    app.logger.setLevel(level)
 
     root = logging.getLogger()
     if not any(isinstance(h, logging.StreamHandler) for h in root.handlers):
         root.addHandler(handler)
-    root.setLevel(logging.INFO)
+    root.setLevel(level)
 
     wl = logging.getLogger("werkzeug")
-    wl.setLevel(logging.INFO)
+    wl.setLevel(level)
     wl.handlers.clear()
     wl.addHandler(handler)
 

--- a/app/routes/admin.py
+++ b/app/routes/admin.py
@@ -1,11 +1,12 @@
 from flask import Blueprint, jsonify
+from app.version import API_PREFIX
 from app.utils import auth_required
 from app.utils import role_required
 from models.user import UserProfile
 from models.shop import Shop
 from models.order import Order
 
-admin_bp = Blueprint("admin", __name__, url_prefix="/api/v1/admin")
+admin_bp = Blueprint("admin", __name__, url_prefix=f"{API_PREFIX}/admin")
 
 @admin_bp.route("/users", methods=["GET"])
 @auth_required

--- a/app/routes/agent.py
+++ b/app/routes/agent.py
@@ -1,9 +1,10 @@
 from flask import Blueprint, request, jsonify
 from app.utils import auth_required
+from app.version import API_PREFIX
 from agent.agent_core import run_agent
 
 # Optional blueprint for AI assistant
-agent_bp = Blueprint('agent', __name__, url_prefix='/api/v1/agent')
+agent_bp = Blueprint('agent', __name__, url_prefix=f'{API_PREFIX}/agent')
 
 @agent_bp.route('/query', methods=['POST'])
 @auth_required

--- a/app/routes/cart.py
+++ b/app/routes/cart.py
@@ -1,5 +1,6 @@
 from flask import Blueprint
 from flask import request, jsonify
+from app.version import API_PREFIX
 from models.cart import CartItem
 from models.shop import Shop
 from models.item import Item
@@ -9,7 +10,7 @@ from app.utils import auth_required
 from app.utils import role_required
 import logging
 from app.utils import internal_error_response
-cart_bp = Blueprint("cart", __name__, url_prefix="/api/v1/cart")
+cart_bp = Blueprint("cart", __name__, url_prefix=f"{API_PREFIX}/cart")
 
 
 MAX_QUANTITY_PER_ITEM = 10  # Set your max quantity per item limit here

--- a/app/routes/item.py
+++ b/app/routes/item.py
@@ -1,6 +1,7 @@
 from flask import Blueprint
 # --- services/item.py ---
 from flask import request, jsonify
+from app.version import API_PREFIX
 from models.item import Item
 from models.shop import Shop
 from models import db
@@ -11,7 +12,7 @@ import pandas as pd
 from werkzeug.utils import secure_filename
 import os
 import logging
-item_bp = Blueprint("item", __name__, url_prefix="/api/v1")
+item_bp = Blueprint("item", __name__, url_prefix=API_PREFIX)
 
 from app.utils import internal_error_response
 

--- a/app/routes/order.py
+++ b/app/routes/order.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, request, jsonify, current_app
+from app.version import API_PREFIX
 from flask_limiter.util import get_remote_address
 from extensions import limiter
 from models import db
@@ -20,7 +21,7 @@ from app.utils import internal_error_response
 from app.services.wallet_ops import adjust_consumer_balance, adjust_vendor_balance, InsufficientFunds
 from models.shop import Shop
 
-order_bp = Blueprint("order", __name__, url_prefix="/api/v1/order")
+order_bp = Blueprint("order", __name__, url_prefix=f"{API_PREFIX}/order")
 
 # ------------------- Helper functions -------------------
 

--- a/app/routes/shop.py
+++ b/app/routes/shop.py
@@ -1,5 +1,6 @@
 from flask import Blueprint
 from flask import request, jsonify
+from app.version import API_PREFIX
 from models.shop import Shop, ShopHours, ShopActionLog
 from datetime import datetime
 from models import db
@@ -7,7 +8,7 @@ from app.utils import auth_required
 from app.utils import role_required
 from models.vendor import VendorProfile
 import logging
-shop_bp = Blueprint("shop", __name__, url_prefix="/api/v1")
+shop_bp = Blueprint("shop", __name__, url_prefix=API_PREFIX)
 
 from app.utils import internal_error_response
 

--- a/app/routes/user.py
+++ b/app/routes/user.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, request, jsonify
+from app.version import API_PREFIX
 from models.user import ConsumerProfile
 from models import db
 from app.utils import auth_required
@@ -6,7 +7,7 @@ from app.utils import role_required
 import logging
 from app.utils import internal_error_response
 
-user_bp = Blueprint("user", __name__, url_prefix="/api/v1")
+user_bp = Blueprint("user", __name__, url_prefix=API_PREFIX)
 
 # Basic onboarding -------------
 @user_bp.route("/onboarding/basic", methods=["POST"])

--- a/app/routes/vendor.py
+++ b/app/routes/vendor.py
@@ -1,4 +1,5 @@
 from flask import Blueprint, request, jsonify
+from app.version import API_PREFIX
 from models.vendor import VendorProfile, VendorDocument, VendorPayoutBank
 from models import db
 from app.utils import auth_required
@@ -7,7 +8,7 @@ from datetime import datetime
 import logging
 from app.utils import internal_error_response
 
-vendor_bp = Blueprint("vendor", __name__, url_prefix="/api/v1/vendor")
+vendor_bp = Blueprint("vendor", __name__, url_prefix=f"{API_PREFIX}/vendor")
 
 # Vendor Onboarding -----------------
 @vendor_bp.route("/profile", methods=["POST"])

--- a/app/routes/wallet.py
+++ b/app/routes/wallet.py
@@ -2,6 +2,7 @@ from flask import Blueprint
 # services/wallet.py
 
 from flask import request, jsonify
+from app.version import API_PREFIX
 from models import db
 from models.wallet import (
     ConsumerWallet,
@@ -11,7 +12,7 @@ from models.wallet import (
 
 )
 from models.vendor import VendorPayoutBank
-wallet_bp = Blueprint("wallet", __name__, url_prefix="/api/v1")
+wallet_bp = Blueprint("wallet", __name__, url_prefix=API_PREFIX)
 from app.utils import auth_required
 from app.utils import role_required
 from decimal import Decimal


### PR DESCRIPTION
## Summary
- stop auto-creating tables in production
- initialize Twilio client from config
- use shared API prefix across routes
- tune logging level by environment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f8d39698833392f8f728d529c8df