### PR TITLE
Add Docker support and CI workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.db
+*.sqlite3
+*.log
+*.pot
+*.pyc
+.git
+.gitignore
+.env
+venv
+.mypy_cache
+.pytest_cache
+*.swp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Run tests
+      run: pytest -q
+    - name: Build Docker image
+      run: docker build -t habrio:ci .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.11-slim
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    APP_ENV=production
+
+# Set work directory
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy project
+COPY . .
+
+# Expose port
+EXPOSE 80
+
+# Run the application
+CMD ["gunicorn", "-w", "4", "-b", "0.0.0.0:80", "wsgi:app"]

--- a/README.md
+++ b/README.md
@@ -66,3 +66,31 @@ Basic admin endpoints protected by JWT auth and `admin` role:
 ### Optional AI assistant
 
 If `OPENAI_API_KEY` is provided in the environment, the service exposes `/api/v1/agent/query` for chat-based assistance. The endpoint requires authentication and returns the assistant's answer along with suggestions.
+
+## Docker
+
+The application can be run in a container using the included `Dockerfile`.
+
+### Build
+```bash
+docker build -t habrio .
+```
+
+### Run
+```bash
+docker run -p 80:80 \
+  -e SECRET_KEY=changeme \
+  -e DATABASE_URL=sqlite:///data.db \
+  habrio
+```
+
+Set `APP_ENV=production` by default in the image. Provide `SECRET_KEY` and
+`DATABASE_URL` at runtime via environment variables or Docker secrets.
+
+A `docker-compose.yml` is included for local development with PostgreSQL.
+
+## Continuous Integration
+
+GitHub Actions will run the test suite on every push and pull request to `main`.
+The workflow installs dependencies, runs `pytest`, and ensures the Docker image
+builds successfully.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.9'
+services:
+  web:
+    build: .
+    ports:
+      - "80:80"
+    environment:
+      - APP_ENV=production
+      - SECRET_KEY=changeme
+      - DATABASE_URL=postgresql://postgres:postgres@db:5432/habrio
+    depends_on:
+      - db
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: habrio
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - db-data:/var/lib/postgresql/data
+volumes:
+  db-data:


### PR DESCRIPTION
## Summary
- containerize the Flask application using a Dockerfile
- provide docker-compose for local Postgres usage
- run tests in GitHub Actions on Python 3.11 and build Docker image
- document Docker usage and CI in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888fc4c4f9c83339de00383d066b415