### PR TITLE
Improve API error handling

### DIFF
--- a/app/routes/cart.py
+++ b/app/routes/cart.py
@@ -10,6 +10,7 @@ from app.utils import auth_required
 from app.utils import role_required
 import logging
 from app.utils import internal_error_response
+from app.utils import error
 cart_bp = Blueprint("cart", __name__, url_prefix=f"{API_PREFIX}/cart")
 
 
@@ -27,24 +28,24 @@ def add_to_cart():
 
     item = Item.query.get(item_id)
     if not item or not item.is_available:
-        return jsonify({"status": "error", "message": "Item not available"}), 404
+        return error("Item not available", status=404)
 
     if quantity < 1:
-        return jsonify({"status": "error", "message": "Quantity must be at least 1"}), 400
+        return error("Quantity must be at least 1", status=400)
 
     if quantity > MAX_QUANTITY_PER_ITEM:
-        return jsonify({"status": "error", "message": f"Cannot add more than {MAX_QUANTITY_PER_ITEM} units per item"}), 400
+        return error(f"Cannot add more than {MAX_QUANTITY_PER_ITEM} units per item", status=400)
 
     existing_items = CartItem.query.filter_by(user_phone=phone).all()
     if existing_items:
         if any(ci.shop_id != item.shop_id for ci in existing_items):
-            return jsonify({"status": "error", "message": "Cart contains items from a different shop"}), 400
+            return error("Cart contains items from a different shop", status=400)
 
     cart_item = CartItem.query.filter_by(user_phone=phone, item_id=item_id).first()
     if cart_item:
         new_quantity = cart_item.quantity + quantity
         if new_quantity > MAX_QUANTITY_PER_ITEM:
-            return jsonify({"status": "error", "message": f"Max limit is {MAX_QUANTITY_PER_ITEM} units"}), 400
+            return error(f"Max limit is {MAX_QUANTITY_PER_ITEM} units", status=400)
         cart_item.quantity = new_quantity
     else:
         cart_item = CartItem(user_phone=phone, item_id=item_id, shop_id=item.shop_id, quantity=quantity)
@@ -70,14 +71,14 @@ def update_cart_quantity():
     quantity = data.get("quantity")
 
     if not item_id or quantity is None:
-        return jsonify({"status": "error", "message": "Item ID and quantity required"}), 400
+        return error("Item ID and quantity required", status=400)
 
     if quantity < 1 or quantity > MAX_QUANTITY_PER_ITEM:
-        return jsonify({"status": "error", "message": f"Quantity must be between 1 and {MAX_QUANTITY_PER_ITEM}"}), 400
+        return error(f"Quantity must be between 1 and {MAX_QUANTITY_PER_ITEM}", status=400)
 
     cart_item = CartItem.query.filter_by(user_phone=phone, item_id=item_id).first()
     if not cart_item:
-        return jsonify({"status": "error", "message": "Item not found in cart"}), 404
+        return error("Item not found in cart", status=404)
 
     cart_item.quantity = quantity
     try:
@@ -160,7 +161,7 @@ def remove_item():
             return internal_error_response()
         return jsonify({"status": "success", "message": "Item removed"}), 200
 
-    return jsonify({"status": "error", "message": "Item not found"}), 404
+    return error("Item not found", status=404)
 
 
 # Clear cart

--- a/app/routes/vendor.py
+++ b/app/routes/vendor.py
@@ -5,6 +5,7 @@ from app.utils import auth_required
 from app.utils import role_required
 import logging
 from app.utils import internal_error_response
+from app.utils import error
 from app.services import vendor_service
 from app.services.vendor_service import ValidationError
 
@@ -23,7 +24,7 @@ def vendor_profile_setup():
         return jsonify({"status": "success", "message": "Vendor profile created"}), 200
     except ValidationError as e:
         db.session.rollback()
-        return jsonify({"status": "error", "message": str(e)}), 400
+        return error(str(e), status=400)
     except Exception as e:
         db.session.rollback()
         logging.error("Failed to create vendor profile: %s", e, exc_info=True)
@@ -45,7 +46,7 @@ def upload_vendor_document():
         return jsonify({"status": "success", "message": "Document uploaded"}), 200
     except ValidationError as e:
         db.session.rollback()
-        return jsonify({"status": "error", "message": str(e)}), 400
+        return error(str(e), status=400)
     except Exception as e:
         db.session.rollback()
         logging.error("Failed to upload vendor document: %s", e, exc_info=True)
@@ -64,7 +65,7 @@ def setup_payout_bank():
         return jsonify({"status": "success", "message": "Payout bank info saved"}), 200
     except ValidationError as e:
         db.session.rollback()
-        return jsonify({"status": "error", "message": str(e)}), 400
+        return error(str(e), status=400)
     except Exception as e:
         db.session.rollback()
         logging.error("Failed to setup payout bank: %s", e, exc_info=True)

--- a/app/utils/responses.py
+++ b/app/utils/responses.py
@@ -17,8 +17,12 @@ def error(message, status=400, code=None):
 
 
 def error_response(message: str, status_code: int):
-    return jsonify({"status": "error", "message": message}), status_code
+    return jsonify({"status": "error", "message": message, "code": status_code}), status_code
 
 
 def internal_error_response():
-    return error_response("An unexpected error occurred, please try again later", 500)
+    """Return a generic 500 response in our standard error envelope."""
+    return error(
+        "An unexpected error occurred, please try again later",
+        status=500,
+    )


### PR DESCRIPTION
## Summary
- use helper `error()` in auth, cart, item, order, shop, user, vendor, wallet routes
- return error envelope from decorators and internal_error_response
- expose consistent error JSON with `code` field
- add global error handlers for exceptions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68892eacd8c88333b71c23e33f83ee7e