### PR TITLE
Improve endpoint validation

### DIFF
--- a/app/routes/order.py
+++ b/app/routes/order.py
@@ -27,6 +27,7 @@ from app.services.order_service import (
     cancel_order_by_vendor,
     complete_return as service_complete_return,
     ValidationError,
+    ALLOWED_VENDOR_STATUSES,
 )
 from app.services.wallet_ops import InsufficientFunds
 from models.shop import Shop
@@ -278,6 +279,8 @@ def update_order_status(order_id):
     user = request.user
     data = request.get_json()
     new_status = data.get("status")
+    if new_status not in ALLOWED_VENDOR_STATUSES:
+        return error("Invalid status", status=400)
     order = Order.query.get(order_id)
     if not order:
         return error("Order not found", status=404)

--- a/app/routes/user.py
+++ b/app/routes/user.py
@@ -4,7 +4,7 @@ from models.user import ConsumerProfile
 from models import db
 from app.utils import auth_required
 from app.utils import role_required
-from app.utils import error
+from app.utils import error, has_required_fields
 import logging
 from app.utils import internal_error_response
 
@@ -17,7 +17,7 @@ def basic_onboarding():
     """Complete initial onboarding details for the authenticated user."""
     data = request.get_json()
     required_fields = ["name", "city", "society", "role"]
-    if not all(field in data for field in required_fields):
+    if not has_required_fields(data, required_fields):
         return error("Missing fields", status=400)
 
     user = request.user

--- a/app/routes/vendor.py
+++ b/app/routes/vendor.py
@@ -8,6 +8,7 @@ from app.utils import internal_error_response
 from app.utils import error
 from app.services import vendor_service
 from app.services.vendor_service import ValidationError
+from app.utils import has_required_fields
 
 vendor_bp = Blueprint("vendor", __name__, url_prefix=f"{API_PREFIX}/vendor")
 
@@ -18,6 +19,9 @@ vendor_bp = Blueprint("vendor", __name__, url_prefix=f"{API_PREFIX}/vendor")
 def vendor_profile_setup():
     user = request.user
     data = request.get_json()
+    required = ["business_type", "business_name", "address"]
+    if not has_required_fields(data, required):
+        return error("Missing required vendor details", status=400)
     try:
         vendor_service.create_vendor_profile(user, data)
         db.session.commit()

--- a/app/services/order_service.py
+++ b/app/services/order_service.py
@@ -11,6 +11,8 @@ from app.services.wallet_ops import adjust_consumer_balance, adjust_vendor_balan
 class ValidationError(Exception):
     pass
 
+ALLOWED_VENDOR_STATUSES = ["accepted", "rejected", "delivered"]
+
 
 def confirm_order(user, payment_mode: str = "cash", delivery_notes: str = "") -> Order:
     cart_items: List[CartItem] = CartItem.query.filter_by(user_phone=user.phone).all()
@@ -146,7 +148,7 @@ def cancel_order_by_consumer(user, order: Order) -> Decimal:
 
 
 def update_status_by_vendor(user, order: Order, new_status: str):
-    if new_status not in ["accepted", "rejected", "delivered"]:
+    if new_status not in ALLOWED_VENDOR_STATUSES:
         raise ValidationError("Invalid status")
     if new_status == "delivered" and order.payment_mode == "wallet" and order.payment_status == "paid":
         amt = Decimal(order.final_amount or order.total_amount)

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,5 +1,6 @@
 from .responses import ok, error, error_response, internal_error_response
 from .auth import auth_required, role_required
+from .validation import has_required_fields
 from .jwt import (
     create_access_token,
     create_refresh_token,
@@ -18,4 +19,5 @@ __all__ = [
     'create_refresh_token',
     'decode_token',
     'TokenError',
+    'has_required_fields',
 ]

--- a/app/utils/validation.py
+++ b/app/utils/validation.py
@@ -1,0 +1,8 @@
+from typing import Iterable
+
+
+def has_required_fields(data: dict, required: Iterable[str]) -> bool:
+    """Return True if all required fields are present in the given dict."""
+    if not isinstance(data, dict):
+        return False
+    return all(field in data for field in required)


### PR DESCRIPTION
## Summary
- introduce `has_required_fields` util
- validate vendor profile data with new helper
- validate basic onboarding with new helper
- check status values against `ALLOWED_VENDOR_STATUSES`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a1c6c09c88333bbe4066fe670da43