### PR TITLE
Update API docs and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ Set `ALLOW_DB_MIGRATIONS=true` in production to permit upgrades or stamping.
 
 
 ## API Versioning
-- All business endpoints are now served under `/api/v1/...`.
+- All business endpoints are served under `/api/v1/...`.
+- Consumer-facing routes live under `/api/v1/consumer/...` (onboarding, profile, orders, etc.).
+- Vendor-facing routes live under `/api/v1/vendor/...` (shop management, orders, payouts, etc.).
+- Common operations like OTP, login and basic onboarding remain directly under `/api/v1/`.
+- Admin endpoints stay under `/api/v1/admin/...`.
 - Error handlers remain global (no prefix).
 - Test-only routes remain unversioned and, in testing, also available under `/api/v1/test_support/...`.
 - Clients should update their base path to `/api/v1`.
@@ -67,6 +71,14 @@ Basic admin endpoints protected by JWT auth and `admin` role:
 - `GET /api/v1/admin/users` - List recent users
 - `GET /api/v1/admin/shops` - List recent shops
 - `GET /api/v1/admin/orders` - List recent orders
+
+Example consumer routes:
+- `POST /api/v1/consumer/onboarding`
+- `GET /api/v1/consumer/profile/me`
+
+Example vendor routes:
+- `POST /api/v1/vendor/shop`
+- `GET /api/v1/vendor/orders`
 
 ### Optional AI assistant
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -52,19 +52,30 @@ def create_app(config_object=None):
     app.limiter = limiter
 
     migrate = Migrate(app, db, compare_type=True, render_as_batch=True)
-    swagger = Swagger(app, config={
-        "headers": [],
-        "specs": [
-            {
-                "endpoint": 'apispec',
-                "route": '/apispec.json',
-                "rule_filter": lambda rule: rule.rule.startswith(f"{API_PREFIX}/"),
-                "model_filter": lambda tag: True,
-            }
-        ],
-        "swagger_ui": True,
-        "specs_route": "/docs/",
-    })
+    swagger = Swagger(
+        app,
+        config={
+            "headers": [],
+            "specs": [
+                {
+                    "endpoint": "apispec",
+                    "route": "/apispec.json",
+                    "rule_filter": lambda rule: rule.rule.startswith(
+                        f"{API_PREFIX}/"
+                    ),
+                    "model_filter": lambda tag: True,
+                }
+            ],
+            "swagger_ui": True,
+            "specs_route": "/docs/",
+        },
+        template={
+            "tags": [
+                {"name": "Consumer", "description": "Consumer-facing endpoints"},
+                {"name": "Vendor", "description": "Vendor-facing endpoints"},
+            ]
+        },
+    )
     metrics = PrometheusMetrics(app, path='/metrics')
     if not app.config.get("TESTING") and not os.environ.get("METRICS_APP_INFO_SET"):
         metrics.info("app_info", "Application info", version="1.0.0")


### PR DESCRIPTION
## Summary
- document consumer and vendor routes in README
- add consumer and vendor tags to swagger config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a36d14fc883338a1f11225551d4c9