### PR TITLE
Align route prefixes

### DIFF
--- a/API_DETAILS.txt
+++ b/API_DETAILS.txt
@@ -178,42 +178,42 @@ GET /consumer/shops/search
 
 Item
 ----
-POST /item/add
+POST /vendor/item/add
     - Auth + vendor role. Body requires title and price, plus optional details.
     - Adds item to vendor's shop.
     Example request:
-        POST /api/v1/item/add
+        POST /api/v1/vendor/item/add
         {"title": "Milk", "price": 2.5}
     Example response:
         {"status": "success", "message": "Item added"}
 
-POST /item/<item_id>/toggle
+POST /vendor/item/<item_id>/toggle
     - Auth + vendor role. Toggles availability of given item if owned by vendor.
     Example request:
-        POST /api/v1/item/1/toggle
+        POST /api/v1/vendor/item/1/toggle
     Example response:
         {"status": "success", "message": "Item availability updated"}
 
-POST /item/update/<item_id>
+POST /vendor/item/update/<item_id>
     - Auth + vendor role. Body with fields to update item.
     Example request:
-        POST /api/v1/item/update/1
+        POST /api/v1/vendor/item/update/1
         {"price": 3.0}
     Example response:
         {"status": "success", "message": "Item updated"}
 
-GET /item/my
+GET /vendor/item/my
     - Auth + vendor role. Returns list of vendor's items.
     Example request:
-        GET /api/v1/item/my
+        GET /api/v1/vendor/item/my
     Example response:
         {"status": "success", "data": [...]}
 
-POST /item/bulk-upload
+POST /vendor/item/bulk-upload
     - Auth + vendor role. Multipart file "file" (.csv/.xls/.xlsx) containing item rows with at least title and price.
     - Creates items in vendor's shop; returns count created.
     Example request:
-        POST /api/v1/item/bulk-upload (multipart/form-data with file)
+        POST /api/v1/vendor/item/bulk-upload (multipart/form-data with file)
     Example response:
         {"status": "success", "message": "X items uploaded"}
 
@@ -362,55 +362,55 @@ GET /consumer/order/history
     Example response:
         {"status": "success", "orders": [...]} 
 
-POST /consumer/order/confirm-modified/<order_id>
+POST /consumer/orders/<order_id>/confirm-modified
     - Auth + consumer role. Confirms vendor modifications to order and refunds difference if any.
     Example request:
-        POST /api/v1/consumer/order/confirm-modified/1
+        POST /api/v1/consumer/orders/1/confirm-modified
     Example response:
         {"status": "success", "refund": 5.0}
 
-POST /consumer/order/cancel/<order_id>
+POST /consumer/orders/<order_id>/cancel
     - Auth + consumer role. Cancels order and refunds if prepaid.
     Example request:
-        POST /api/v1/consumer/order/cancel/1
+        POST /api/v1/consumer/orders/1/cancel
     Example response:
         {"status": "success", "message": "Order cancelled", "refund": 10.0}
 
-POST /consumer/order/message/send/<order_id>
+POST /consumer/orders/<order_id>/message
     - Auth + consumer role. Body: message. Sends message on order.
     Example request:
-        POST /api/v1/consumer/order/message/send/1
+        POST /api/v1/consumer/orders/1/message
         {"message": "When will it arrive?"}
     Example response:
         {"status": "success", "message": "Message sent"}
 
-GET /consumer/order/messages/<order_id>
+GET /consumer/orders/<order_id>/messages
     - Auth + consumer role. Retrieves message history for order.
     Example request:
-        GET /api/v1/consumer/order/messages/1
+        GET /api/v1/consumer/orders/1/messages
     Example response:
         {"status": "success", "messages": [...]} 
 
-POST /consumer/order/rate/<order_id>
+POST /consumer/orders/<order_id>/rate
     - Auth + consumer role. Body: rating (1-5), review(optional). Rates delivered order.
     Example request:
-        POST /api/v1/consumer/order/rate/1
+        POST /api/v1/consumer/orders/1/rate
         {"rating": 5, "review": "Great"}
     Example response:
         {"status": "success", "message": "Thank you for rating!"}
 
-POST /consumer/order/issue/<order_id>
+POST /consumer/orders/<order_id>/issue
     - Auth + consumer role. Body: issue_type, description. Raises issue for delivered order.
     Example request:
-        POST /api/v1/consumer/order/issue/1
+        POST /api/v1/consumer/orders/1/issue
         {"issue_type": "missing_item", "description": "Item X not delivered"}
     Example response:
         {"status": "success", "message": "Issue raised"}
 
-POST /consumer/order/return/raise/<order_id>
+POST /consumer/orders/<order_id>/return/raise
     - Auth + consumer role. Body: reason, items[{item_id, quantity}]. Requests return of items from delivered order.
     Example request:
-        POST /api/v1/consumer/order/return/raise/1
+        POST /api/v1/consumer/orders/1/return/raise
         {"reason": "damaged", "items": [{"item_id": 1, "quantity": 1}]}
     Example response:
         {"status": "success", "message": "Return request sent"}

--- a/app/api.py
+++ b/app/api.py
@@ -2,7 +2,6 @@ from app.routes import (
     auth_bp,
     user_bp,
     vendor_bp,
-    item_bp,
     consumer_bp,
     admin_bp,
     agent_bp,
@@ -16,7 +15,6 @@ def register_api_v1(app):
     app.register_blueprint(auth_bp)
     app.register_blueprint(user_bp)
     app.register_blueprint(vendor_bp)
-    app.register_blueprint(item_bp)
     app.register_blueprint(consumer_bp)
     app.register_blueprint(admin_bp)
     if os.environ.get("OPENAI_API_KEY") and agent_bp:

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,7 +1,6 @@
 from .onboarding.auth import auth_bp
 from .onboarding.user import user_bp
 from .vendor import vendor_bp
-from .vendor.items import item_bp
 from .consumer import consumer_bp
 from .admin import admin_bp
 try:
@@ -17,5 +16,4 @@ __all__ = [
     'consumer_bp',
     'admin_bp',
     'agent_bp',
-    'item_bp',
 ]

--- a/app/routes/consumer/orders.py
+++ b/app/routes/consumer/orders.py
@@ -79,7 +79,7 @@ def get_order_history():
     return jsonify({"status": "success", "orders": result}), 200
 
 
-@consumer_bp.route("/order/confirm-modified/<int:order_id>", methods=["POST"])
+@consumer_bp.route("/orders/<int:order_id>/confirm-modified", methods=["POST"])
 @auth_required
 @role_required("consumer")
 def confirm_modified_order(order_id):
@@ -98,7 +98,7 @@ def confirm_modified_order(order_id):
         return internal_error_response()
 
 
-@consumer_bp.route("/order/cancel/<int:order_id>", methods=["POST"])
+@consumer_bp.route("/orders/<int:order_id>/cancel", methods=["POST"])
 @auth_required
 @role_required("consumer")
 def cancel_order_consumer(order_id):
@@ -117,7 +117,7 @@ def cancel_order_consumer(order_id):
         return internal_error_response()
 
 
-@consumer_bp.route("/order/message/send/<int:order_id>", methods=["POST"])
+@consumer_bp.route("/orders/<int:order_id>/message", methods=["POST"])
 @auth_required
 @role_required("consumer")
 def send_order_message_consumer(order_id):
@@ -139,7 +139,7 @@ def send_order_message_consumer(order_id):
     return jsonify({"status": "success", "message": "Message sent"}), 200
 
 
-@consumer_bp.route("/order/messages/<int:order_id>", methods=["GET"])
+@consumer_bp.route("/orders/<int:order_id>/messages", methods=["GET"])
 @auth_required
 @role_required("consumer")
 def get_order_messages_consumer(order_id):
@@ -152,7 +152,7 @@ def get_order_messages_consumer(order_id):
     return jsonify({"status": "success", "messages": result}), 200
 
 
-@consumer_bp.route("/order/rate/<int:order_id>", methods=["POST"])
+@consumer_bp.route("/orders/<int:order_id>/rate", methods=["POST"])
 @auth_required
 @role_required("consumer")
 def rate_order(order_id):
@@ -188,7 +188,7 @@ def rate_order(order_id):
     return jsonify({"status": "success", "message": "Thank you for rating!", "rating": rating_entry.to_dict()}), 200
 
 
-@consumer_bp.route("/order/issue/<int:order_id>", methods=["POST"])
+@consumer_bp.route("/orders/<int:order_id>/issue", methods=["POST"])
 @auth_required
 @role_required("consumer")
 def raise_order_issue(order_id):
@@ -220,7 +220,7 @@ def raise_order_issue(order_id):
     return jsonify({"status": "success", "message": "Issue raised"}), 200
 
 
-@consumer_bp.route("/order/return/raise/<int:order_id>", methods=["POST"])
+@consumer_bp.route("/orders/<int:order_id>/return/raise", methods=["POST"])
 @auth_required
 @role_required("consumer")
 def request_return(order_id):

--- a/app/routes/vendor/items.py
+++ b/app/routes/vendor/items.py
@@ -2,16 +2,13 @@ from flask import request, jsonify
 from datetime import datetime
 import pandas as pd
 from werkzeug.utils import secure_filename
-from app.version import API_PREFIX
 from models.item import Item
 from models.shop import Shop
 from models import db
-from flask import Blueprint
 from app.utils import auth_required, role_required, transactional, error, internal_error_response
+from . import vendor_bp
 
-item_bp = Blueprint("item", __name__, url_prefix=API_PREFIX)
-
-@item_bp.route('/item/add', methods=['POST'])
+@vendor_bp.route('/item/add', methods=['POST'])
 @auth_required
 @role_required(['vendor'])
 def add_item():
@@ -49,7 +46,7 @@ def add_item():
         return internal_error_response()
     return jsonify({"status": "success", "message": "Item added"}), 200
 
-@item_bp.route('/item/<int:item_id>/toggle', methods=['POST'])
+@vendor_bp.route('/item/<int:item_id>/toggle', methods=['POST'])
 @auth_required
 @role_required(['vendor'])
 def toggle_item_availability(item_id):
@@ -66,7 +63,7 @@ def toggle_item_availability(item_id):
         return internal_error_response()
     return jsonify({"status": "success", "message": "Item availability updated"}), 200
 
-@item_bp.route('/item/update/<int:item_id>', methods=['POST'])
+@vendor_bp.route('/item/update/<int:item_id>', methods=['POST'])
 @auth_required
 @role_required(['vendor'])
 def update_item(item_id):
@@ -98,7 +95,7 @@ def update_item(item_id):
         return internal_error_response()
     return jsonify({"status": "success", "message": "Item updated"}), 200
 
-@item_bp.route('/item/my', methods=['GET'])
+@vendor_bp.route('/item/my', methods=['GET'])
 @auth_required
 @role_required(['vendor'])
 def get_items():
@@ -130,7 +127,7 @@ def get_items():
     ]
     return jsonify({"status": "success", "data": result}), 200
 
-@item_bp.route('/item/bulk-upload', methods=['POST'])
+@vendor_bp.route('/item/bulk-upload', methods=['POST'])
 @auth_required
 @role_required(['vendor'])
 def bulk_upload_items():

--- a/tests/test_shop_item.py
+++ b/tests/test_shop_item.py
@@ -42,7 +42,7 @@ def create_shop_for_vendor(client, token, name='MyShop'):
 
 def add_item_for_vendor(client, token, title='Item', price=1.0):
     payload = {'title': title, 'price': price}
-    return client.post(f"{API_PREFIX}/item/add", json=payload, headers={'Authorization': f'Bearer {token}'})
+    return client.post(f"{API_PREFIX}/vendor/item/add", json=payload, headers={'Authorization': f'Bearer {token}'})
 
 
 def test_create_shop_success_and_duplicate(client, app):
@@ -122,7 +122,7 @@ def test_add_item_success_and_errors(client, app):
         item = Item.query.filter_by(shop_id=shop.id).first()
         assert item.title == 'Item1'
 
-    resp_missing = client.post('/api/v1/item/add', json={'title': 'NoPrice'}, headers={'Authorization': f'Bearer {token}'})
+    resp_missing = client.post('/api/v1/vendor/item/add', json={'title': 'NoPrice'}, headers={'Authorization': f'Bearer {token}'})
     assert resp_missing.status_code == 400
 
     phone2 = '8100000007'
@@ -141,20 +141,20 @@ def test_update_item(client, app):
         shop = Shop.query.filter_by(phone=phone).first()
         item_id = Item.query.filter_by(shop_id=shop.id).first().id
 
-    resp = client.post(f'/api/v1/item/update/{item_id}', json={'price': 8, 'quantity_in_stock': 10}, headers={'Authorization': f'Bearer {token}'})
+    resp = client.post(f'/api/v1/vendor/item/update/{item_id}', json={'price': 8, 'quantity_in_stock': 10}, headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 200
     with app.app_context():
         item = Item.query.get(item_id)
         assert item.price == 8
         assert item.quantity_in_stock == 10
 
-    resp_bad = client.post(f'/api/v1/item/update/{item_id + 999}', json={'price': 9}, headers={'Authorization': f'Bearer {token}'})
+    resp_bad = client.post(f'/api/v1/vendor/item/update/{item_id + 999}', json={'price': 9}, headers={'Authorization': f'Bearer {token}'})
     assert resp_bad.status_code == 404
 
     phone2 = '8100000009'
     token2 = setup_vendor_with_profile(client, app, phone2)
     create_shop_for_vendor(client, token2, 'OtherShop')
-    resp_unauth = client.post(f'/api/v1/item/update/{item_id}', json={'price': 7}, headers={'Authorization': f'Bearer {token2}'})
+    resp_unauth = client.post(f'/api/v1/vendor/item/update/{item_id}', json={'price': 7}, headers={'Authorization': f'Bearer {token2}'})
     assert resp_unauth.status_code == 404
 
 
@@ -168,12 +168,12 @@ def test_toggle_item_availability(client, app):
         item_id = Item.query.filter_by(shop_id=shop.id).first().id
         assert Item.query.get(item_id).is_available is True
 
-    resp1 = client.post(f'/api/v1/item/{item_id}/toggle', headers={'Authorization': f'Bearer {token}'})
+    resp1 = client.post(f'/api/v1/vendor/item/{item_id}/toggle', headers={'Authorization': f'Bearer {token}'})
     assert resp1.status_code == 200
     with app.app_context():
         assert Item.query.get(item_id).is_available is False
 
-    resp2 = client.post(f'/api/v1/item/{item_id}/toggle', headers={'Authorization': f'Bearer {token}'})
+    resp2 = client.post(f'/api/v1/vendor/item/{item_id}/toggle', headers={'Authorization': f'Bearer {token}'})
     assert resp2.status_code == 200
     with app.app_context():
         assert Item.query.get(item_id).is_available is True
@@ -181,7 +181,7 @@ def test_toggle_item_availability(client, app):
     phone2 = '8100000011'
     token2 = setup_vendor_with_profile(client, app, phone2)
     create_shop_for_vendor(client, token2, 'Shop2')
-    resp_unauth = client.post(f'/api/v1/item/{item_id}/toggle', headers={'Authorization': f'Bearer {token2}'})
+    resp_unauth = client.post(f'/api/v1/vendor/item/{item_id}/toggle', headers={'Authorization': f'Bearer {token2}'})
     assert resp_unauth.status_code == 404
 
 
@@ -192,7 +192,7 @@ def test_get_items(client, app):
     add_item_for_vendor(client, token, 'L1', 1)
     add_item_for_vendor(client, token, 'L2', 2)
 
-    resp = client.get('/api/v1/item/my', headers={'Authorization': f'Bearer {token}'})
+    resp = client.get('/api/v1/vendor/item/my', headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 200
     data = resp.get_json()['data']
     assert len(data) == 2
@@ -201,7 +201,7 @@ def test_get_items(client, app):
 
     phone2 = '8100000013'
     token2 = setup_vendor_with_profile(client, app, phone2)
-    resp_no_shop = client.get('/api/v1/item/my', headers={'Authorization': f'Bearer {token2}'})
+    resp_no_shop = client.get('/api/v1/vendor/item/my', headers={'Authorization': f'Bearer {token2}'})
     assert resp_no_shop.status_code == 404
     assert resp_no_shop.get_json()['message'] == 'Shop not found'
 
@@ -215,14 +215,14 @@ def test_bulk_upload_items(client, app):
     csv_io = io.BytesIO()
     csv_io.write(df.to_csv(index=False).encode())
     csv_io.seek(0)
-    resp = client.post('/api/v1/item/bulk-upload', data={'file': (csv_io, 'items.csv')}, headers={'Authorization': f'Bearer {token}'}, content_type='multipart/form-data')
+    resp = client.post('/api/v1/vendor/item/bulk-upload', data={'file': (csv_io, 'items.csv')}, headers={'Authorization': f'Bearer {token}'}, content_type='multipart/form-data')
     assert resp.status_code == 200
     assert '2 items uploaded' in resp.get_json()['message']
     with app.app_context():
         shop = Shop.query.filter_by(phone=phone).first()
         assert Item.query.filter_by(shop_id=shop.id).count() == 2
 
-    resp_ext = client.post('/api/v1/item/bulk-upload', data={'file': (io.BytesIO(b'abc'), 'items.txt')}, headers={'Authorization': f'Bearer {token}'}, content_type='multipart/form-data')
+    resp_ext = client.post('/api/v1/vendor/item/bulk-upload', data={'file': (io.BytesIO(b'abc'), 'items.txt')}, headers={'Authorization': f'Bearer {token}'}, content_type='multipart/form-data')
     assert resp_ext.status_code == 400
     assert resp_ext.get_json()['message'] == 'Unsupported file type'
 
@@ -230,7 +230,7 @@ def test_bulk_upload_items(client, app):
     csv_io2 = io.BytesIO()
     csv_io2.write(df2.to_csv(index=False).encode())
     csv_io2.seek(0)
-    resp_missing = client.post('/api/v1/item/bulk-upload', data={'file': (csv_io2, 'bad.csv')}, headers={'Authorization': f'Bearer {token}'}, content_type='multipart/form-data')
+    resp_missing = client.post('/api/v1/vendor/item/bulk-upload', data={'file': (csv_io2, 'bad.csv')}, headers={'Authorization': f'Bearer {token}'}, content_type='multipart/form-data')
     assert resp_missing.status_code == 400
     assert 'Missing columns' in resp_missing.get_json()['message']
 


### PR DESCRIPTION
## Summary
- register vendor item routes under /api/v1/vendor
- change consumer order routes to use `/orders/<id>/...`
- adjust tests and docs for new URLs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a8d9e4db8833385a60df17cf334b9