### PR TITLE
Implement JSON logging with masking

### DIFF
--- a/logging.md
+++ b/logging.md
@@ -1,0 +1,18 @@
+# Logging Policy
+
+This project uses JSON formatted logs with a global masking filter.
+Sensitive fields such as passwords, OTP codes, tokens and email addresses are removed
+from logs unless DEBUG level logging is enabled in a non-production environment.
+
+## Examples
+
+```python
+logger.info({"email": "user@example.com", "otp": "123456"})
+# -> {"email": "[REDACTED]", "otp": "[REDACTED]", ...}
+
+logger.debug({"password": "secret"})  # in development
+# -> {"password": "secret", ...}
+```
+
+Ensure any structured data passed to loggers uses dictionaries so the masking
+filter can properly sanitize values.

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,5 +1,6 @@
 import importlib
 import sys
+import logging
 
 import pytest
 
@@ -37,4 +38,36 @@ def test_logs_include_request_id_attribute(monkeypatch, caplog):
     resp = client.get("/__log", headers={"X-Request-ID": "rid-abc"})
     assert resp.status_code == 200
     assert any(getattr(r, "request_id", "") == "rid-abc" for r in caplog.records)
+
+
+def test_sensitive_fields_masked_in_info(monkeypatch, caplog):
+    from app.logging import MaskingFilter
+    monkeypatch.setenv("LOG_LEVEL", "INFO")
+    app = load_app(monkeypatch)
+    app.config.update(TESTING=True)
+    caplog.set_level("INFO")
+    caplog.handler.addFilter(MaskingFilter())
+    logger = logging.getLogger("mask_test")
+    with app.app_context():
+        logger.info({"email": "user@example.com", "otp": "123456"})
+    record = next(r for r in caplog.records if r.name == "mask_test")
+    assert isinstance(record.msg, dict)
+    assert record.msg["email"] == "[REDACTED]"
+    assert record.msg["otp"] == "[REDACTED]"
+
+
+def test_sensitive_fields_visible_in_debug(monkeypatch, caplog):
+    from app.logging import MaskingFilter
+    monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+    monkeypatch.setenv("APP_ENV", "development")
+    app = load_app(monkeypatch)
+    app.config.update(TESTING=True)
+    caplog.set_level("DEBUG")
+    caplog.handler.addFilter(MaskingFilter())
+    logger = logging.getLogger("mask_test_debug")
+    with app.app_context():
+        logger.debug({"password": "secret"})
+    record = next(r for r in caplog.records if r.name == "mask_test_debug")
+    assert isinstance(record.msg, dict)
+    assert record.msg["password"] == "secret"
 


### PR DESCRIPTION
## Summary
- add a JSON logger and masking filter for sensitive fields
- expose environment-based log level configuration
- add tests for log masking
- document logging policy

## Testing
- `pytest -q tests/test_logging.py::test_sensitive_fields_masked_in_info`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aa57f9c388333876d07f801102167