### PR TITLE
Blueprint-level role enforcement

### DIFF
--- a/app/routes/admin/__init__.py
+++ b/app/routes/admin/__init__.py
@@ -1,30 +1,31 @@
 from flask import Blueprint, jsonify
 from app.version import API_PREFIX
-from app.utils import auth_required
-from app.utils import role_required
+from app.utils import auth_required, role_required
 from models.user import UserProfile
 from models.shop import Shop
 from models.order import Order
 
 admin_bp = Blueprint("admin", __name__, url_prefix=f"{API_PREFIX}/admin")
 
-@admin_bp.route("/users", methods=["GET"])
+
+@admin_bp.before_request
 @auth_required
 @role_required("admin")
+def _enforce_admin_role():
+    """Ensure the requester is an authenticated admin."""
+    return None
+
+@admin_bp.route("/users", methods=["GET"])
 def list_users():
     users = UserProfile.query.limit(50).all()
     return jsonify({"status": "success", "users": [u.phone for u in users]}), 200
 
 @admin_bp.route("/shops", methods=["GET"])
-@auth_required
-@role_required("admin")
 def list_shops():
     shops = Shop.query.limit(50).all()
     return jsonify({"status": "success", "shops": [{"id": s.id, "name": s.shop_name} for s in shops]}), 200
 
 @admin_bp.route("/orders", methods=["GET"])
-@auth_required
-@role_required("admin")
 def list_orders():
     orders = Order.query.order_by(Order.id.desc()).limit(50).all()
     return jsonify({"status": "success", "orders": [{"id": o.id, "status": o.status} for o in orders]}), 200

--- a/app/routes/consumer/__init__.py
+++ b/app/routes/consumer/__init__.py
@@ -1,7 +1,16 @@
 from flask import Blueprint
 from app.version import API_PREFIX
+from app.utils import auth_required, role_required
 
 consumer_bp = Blueprint("consumer", __name__, url_prefix=f"{API_PREFIX}/consumer")
+
+
+@consumer_bp.before_request
+@auth_required
+@role_required("consumer")
+def _enforce_consumer_role():
+    """Ensure the requester is an authenticated consumer."""
+    return None
 
 from . import profile  # noqa: E402
 from . import cart  # noqa: E402

--- a/app/routes/consumer/cart.py
+++ b/app/routes/consumer/cart.py
@@ -3,13 +3,11 @@ from models import db
 from models.cart import CartItem
 from models.item import Item
 from decimal import Decimal
-from app.utils import auth_required, role_required, transactional, error, internal_error_response
+from app.utils import transactional, error, internal_error_response
 from . import consumer_bp
 
 
 @consumer_bp.route("/cart/add", methods=["POST"])
-@auth_required
-@role_required("consumer")
 def add_to_cart():
     data = request.get_json()
     phone = request.phone
@@ -45,8 +43,6 @@ def add_to_cart():
 
 
 @consumer_bp.route("/cart/update", methods=["POST"])
-@auth_required
-@role_required("consumer")
 def update_cart_quantity():
     data = request.get_json()
     phone = request.phone
@@ -70,8 +66,6 @@ def update_cart_quantity():
 
 
 @consumer_bp.route("/cart/view", methods=["GET"])
-@auth_required
-@role_required("consumer")
 def view_cart():
     phone = request.phone
     items = CartItem.query.filter_by(user_phone=phone).all()
@@ -113,8 +107,6 @@ def view_cart():
 
 
 @consumer_bp.route("/cart/remove", methods=["POST"])
-@auth_required
-@role_required("consumer")
 def remove_item():
     data = request.get_json()
     phone = request.phone
@@ -132,8 +124,6 @@ def remove_item():
 
 
 @consumer_bp.route("/cart/clear", methods=["POST"])
-@auth_required
-@role_required("consumer")
 def clear_cart():
     phone = request.phone
     CartItem.query.filter_by(user_phone=phone).delete()

--- a/app/routes/consumer/items.py
+++ b/app/routes/consumer/items.py
@@ -1,12 +1,10 @@
 from flask import request, jsonify
-from app.utils import auth_required, role_required, error
+from app.utils import error
 from models.item import Item
 from models.shop import Shop
 from . import consumer_bp
 
 @consumer_bp.route('/shop/<int:shop_id>/items', methods=['GET'])
-@auth_required
-@role_required(['consumer'])
 def view_items_by_shop(shop_id):
     shop = Shop.query.get(shop_id)
     if not shop:

--- a/app/routes/consumer/orders.py
+++ b/app/routes/consumer/orders.py
@@ -17,7 +17,7 @@ from models.cart import CartItem
 from models.item import Item
 from app.services.consumer.wallet import adjust_consumer_balance, InsufficientFunds
 from app.services.vendor.wallet import adjust_vendor_balance
-from app.utils import auth_required, role_required, transactional, error, internal_error_response
+from app.utils import transactional, error, internal_error_response
 from . import consumer_bp
 from app.services.consumer.orders import (
     ValidationError,
@@ -31,8 +31,6 @@ ALLOWED_VENDOR_STATUSES = ["accepted", "rejected", "delivered"]
 
 @consumer_bp.route("/order/confirm", methods=["POST"])
 @limiter.limit(lambda: current_app.config["ORDER_LIMIT_PER_IP"], key_func=get_remote_address, error_message="Too many orders from this IP")
-@auth_required
-@role_required("consumer")
 def confirm_order():
     user = request.user
     data = request.get_json()
@@ -52,8 +50,6 @@ def confirm_order():
 
 
 @consumer_bp.route("/order/history", methods=["GET"])
-@auth_required
-@role_required("consumer")
 def get_order_history():
     user = request.user
     orders = Order.query.filter_by(user_phone=user.phone).order_by(Order.created_at.desc()).all()
@@ -80,8 +76,6 @@ def get_order_history():
 
 
 @consumer_bp.route("/orders/<int:order_id>/confirm-modified", methods=["POST"])
-@auth_required
-@role_required("consumer")
 def confirm_modified_order(order_id):
     user = request.user
     order = Order.query.get(order_id)
@@ -99,8 +93,6 @@ def confirm_modified_order(order_id):
 
 
 @consumer_bp.route("/orders/<int:order_id>/cancel", methods=["POST"])
-@auth_required
-@role_required("consumer")
 def cancel_order_consumer(order_id):
     user = request.user
     order = Order.query.get(order_id)
@@ -118,8 +110,6 @@ def cancel_order_consumer(order_id):
 
 
 @consumer_bp.route("/orders/<int:order_id>/message", methods=["POST"])
-@auth_required
-@role_required("consumer")
 def send_order_message_consumer(order_id):
     user = request.user
     data = request.get_json()
@@ -140,8 +130,6 @@ def send_order_message_consumer(order_id):
 
 
 @consumer_bp.route("/orders/<int:order_id>/messages", methods=["GET"])
-@auth_required
-@role_required("consumer")
 def get_order_messages_consumer(order_id):
     user = request.user
     order = Order.query.get(order_id)
@@ -153,8 +141,6 @@ def get_order_messages_consumer(order_id):
 
 
 @consumer_bp.route("/orders/<int:order_id>/rate", methods=["POST"])
-@auth_required
-@role_required("consumer")
 def rate_order(order_id):
     user = request.user
     data = request.get_json()
@@ -189,8 +175,6 @@ def rate_order(order_id):
 
 
 @consumer_bp.route("/orders/<int:order_id>/issue", methods=["POST"])
-@auth_required
-@role_required("consumer")
 def raise_order_issue(order_id):
     user = request.user
     data = request.get_json()
@@ -221,8 +205,6 @@ def raise_order_issue(order_id):
 
 
 @consumer_bp.route("/orders/<int:order_id>/return/raise", methods=["POST"])
-@auth_required
-@role_required("consumer")
 def request_return(order_id):
     user = request.user
     data = request.get_json()

--- a/app/routes/consumer/profile.py
+++ b/app/routes/consumer/profile.py
@@ -1,13 +1,11 @@
 from flask import request, jsonify
 from models import db
 from models.user import ConsumerProfile
-from app.utils import auth_required, role_required, transactional, error, internal_error_response
+from app.utils import transactional, error, internal_error_response
 from . import consumer_bp
 
 
 @consumer_bp.route("/onboarding", methods=["POST"])
-@auth_required
-@role_required(["consumer"])
 def consumer_onboarding():
     user = request.user
     if not user or not user.basic_onboarding_done:
@@ -39,8 +37,6 @@ def consumer_onboarding():
 
 
 @consumer_bp.route("/profile/me", methods=["GET"])
-@auth_required
-@role_required(["consumer"])
 def get_consumer_profile():
     user = request.user
     if not user:
@@ -53,8 +49,6 @@ def get_consumer_profile():
 
 
 @consumer_bp.route("/profile/edit", methods=["POST"])
-@auth_required
-@role_required(["consumer"])
 def edit_consumer_profile():
     user = request.user
     profile = ConsumerProfile.query.filter_by(user_phone=user.phone).first()

--- a/app/routes/consumer/shops.py
+++ b/app/routes/consumer/shops.py
@@ -1,13 +1,11 @@
 from flask import request, jsonify
 from models import db
 from models.shop import Shop
-from app.utils import auth_required, role_required, error
+from app.utils import error
 from . import consumer_bp
 
 
 @consumer_bp.route("/shops", methods=["GET"])
-@auth_required
-@role_required(["consumer"])
 def list_shops():
     user = request.user
     city, society = user.city, user.society
@@ -42,8 +40,6 @@ def list_shops():
 
 
 @consumer_bp.route("/shops/search", methods=["GET"])
-@auth_required
-@role_required(["consumer"])
 def search_shops():
     user = request.user
     city = user.city

--- a/app/routes/consumer/wallet.py
+++ b/app/routes/consumer/wallet.py
@@ -6,13 +6,11 @@ from app.services.consumer.wallet import (
     adjust_consumer_balance,
     InsufficientFunds,
 )
-from app.utils import auth_required, role_required, transactional, error, internal_error_response
+from app.utils import transactional, error, internal_error_response
 from . import consumer_bp
 
 
 @consumer_bp.route("/wallet", methods=["GET"])
-@auth_required
-@role_required(["consumer"])
 def get_or_create_wallet():
     user = request.user
     wallet = ConsumerWallet.query.filter_by(user_phone=user.phone).first()
@@ -27,8 +25,6 @@ def get_or_create_wallet():
 
 
 @consumer_bp.route("/wallet/history", methods=["GET"])
-@auth_required
-@role_required(["consumer"])
 def wallet_transaction_history():
     txns = (
         WalletTransaction.query.filter_by(user_phone=request.phone)
@@ -41,8 +37,6 @@ def wallet_transaction_history():
 
 
 @consumer_bp.route("/wallet/load", methods=["POST"])
-@auth_required
-@role_required(["consumer"])
 def load_wallet():
     user = request.user
     data = request.get_json()
@@ -67,8 +61,6 @@ def load_wallet():
 
 
 @consumer_bp.route("/wallet/debit", methods=["POST"])
-@auth_required
-@role_required(["consumer"])
 def debit_wallet():
     user = request.user
     data = request.get_json()
@@ -92,8 +84,6 @@ def debit_wallet():
 
 
 @consumer_bp.route("/wallet/refund", methods=["POST"])
-@auth_required
-@role_required(["consumer"])
 def refund_wallet():
     user = request.user
     data = request.get_json()

--- a/app/routes/vendor/__init__.py
+++ b/app/routes/vendor/__init__.py
@@ -1,7 +1,16 @@
 from flask import Blueprint
 from app.version import API_PREFIX
+from app.utils import auth_required, role_required
 
 vendor_bp = Blueprint("vendor", __name__, url_prefix=f"{API_PREFIX}/vendor")
+
+
+@vendor_bp.before_request
+@auth_required
+@role_required("vendor")
+def _enforce_vendor_role():
+    """Ensure the requester is an authenticated vendor."""
+    return None
 
 from . import profile  # noqa: E402
 from . import shop  # noqa: E402

--- a/app/routes/vendor/items.py
+++ b/app/routes/vendor/items.py
@@ -5,14 +5,12 @@ from werkzeug.utils import secure_filename
 from models.item import Item
 from models.shop import Shop
 from models import db
-from app.utils import auth_required, role_required, transactional, error, internal_error_response
+from app.utils import transactional, error, internal_error_response
 from app.utils.validation import validate_schema
 from app.schemas.vendor import AddItemRequest
 from . import vendor_bp
 
 @vendor_bp.route('/item/add', methods=['POST'])
-@auth_required
-@role_required(['vendor'])
 @validate_schema(AddItemRequest)
 def add_item():
     user = request.user
@@ -47,8 +45,6 @@ def add_item():
     return jsonify({"status": "success", "message": "Item added"}), 200
 
 @vendor_bp.route('/item/<int:item_id>/toggle', methods=['POST'])
-@auth_required
-@role_required(['vendor'])
 def toggle_item_availability(item_id):
     user = request.user
     item = Item.query.get(item_id)
@@ -64,8 +60,6 @@ def toggle_item_availability(item_id):
     return jsonify({"status": "success", "message": "Item availability updated"}), 200
 
 @vendor_bp.route('/item/update/<int:item_id>', methods=['POST'])
-@auth_required
-@role_required(['vendor'])
 def update_item(item_id):
     user = request.user
     data = request.get_json()
@@ -96,8 +90,6 @@ def update_item(item_id):
     return jsonify({"status": "success", "message": "Item updated"}), 200
 
 @vendor_bp.route('/item/my', methods=['GET'])
-@auth_required
-@role_required(['vendor'])
 def get_items():
     user = request.user
     shop = Shop.query.filter_by(phone=user.phone).first()
@@ -128,8 +120,6 @@ def get_items():
     return jsonify({"status": "success", "data": result}), 200
 
 @vendor_bp.route('/item/bulk-upload', methods=['POST'])
-@auth_required
-@role_required(['vendor'])
 def bulk_upload_items():
     user = request.user
     file = request.files.get("file")

--- a/app/routes/vendor/orders.py
+++ b/app/routes/vendor/orders.py
@@ -13,7 +13,7 @@ from models.order import (
 )
 from app.services.consumer.wallet import adjust_consumer_balance, InsufficientFunds
 from app.services.vendor.wallet import adjust_vendor_balance
-from app.utils import auth_required, role_required, transactional, error, internal_error_response
+from app.utils import role_required, transactional, error, internal_error_response
 from . import vendor_bp
 from app.services.vendor.orders import (
     OrderValidationError,
@@ -26,8 +26,6 @@ from app.services.vendor.orders import (
 
 
 @vendor_bp.route("/orders", methods=["GET"])
-@auth_required
-@role_required("vendor")
 def get_shop_orders():
     user = request.user
     shop = Shop.query.filter_by(phone=user.phone).first()
@@ -63,7 +61,6 @@ def get_shop_orders():
 
 
 @vendor_bp.route("/orders/<int:order_id>/status", methods=["POST"])
-@auth_required
 @role_required("vendor:deliver_order")
 def update_order_status(order_id):
     user = request.user
@@ -91,7 +88,6 @@ def update_order_status(order_id):
 
 
 @vendor_bp.route("/orders/<int:order_id>/modify", methods=["POST"])
-@auth_required
 @role_required("vendor:modify_order")
 def modify_order_item(order_id):
     user = request.user
@@ -134,7 +130,6 @@ def modify_order_item(order_id):
 
 
 @vendor_bp.route("/orders/<int:order_id>/cancel", methods=["POST"])
-@auth_required
 @role_required("vendor:cancel_order_vendor")
 def cancel_order_vendor(order_id):
     user = request.user
@@ -157,7 +152,6 @@ def cancel_order_vendor(order_id):
 
 
 @vendor_bp.route("/orders/<int:order_id>/message", methods=["POST"])
-@auth_required
 @role_required("vendor")
 def send_order_message_vendor(order_id):
     user = request.user
@@ -180,7 +174,6 @@ def send_order_message_vendor(order_id):
 
 
 @vendor_bp.route("/orders/<int:order_id>/messages", methods=["GET"])
-@auth_required
 @role_required("vendor")
 def get_order_messages_vendor(order_id):
     user = request.user
@@ -194,7 +187,6 @@ def get_order_messages_vendor(order_id):
 
 
 @vendor_bp.route("/orders/issues", methods=["GET"])
-@auth_required
 @role_required("vendor")
 def get_order_issues():
     user = request.user
@@ -218,7 +210,6 @@ def get_order_issues():
 
 
 @vendor_bp.route("/orders/<int:order_id>/return/accept", methods=["POST"])
-@auth_required
 @role_required("vendor")
 def accept_return(order_id):
     user = request.user
@@ -252,7 +243,6 @@ def accept_return(order_id):
 
 
 @vendor_bp.route("/orders/<int:order_id>/return/complete", methods=["POST"])
-@auth_required
 @role_required("vendor")
 def complete_return(order_id):
     user = request.user
@@ -276,7 +266,6 @@ def complete_return(order_id):
 
 
 @vendor_bp.route("/orders/<int:order_id>/return/initiate", methods=["POST"])
-@auth_required
 @role_required("vendor")
 def vendor_initiate_return(order_id):
     user = request.user

--- a/app/routes/vendor/profile.py
+++ b/app/routes/vendor/profile.py
@@ -1,6 +1,6 @@
 from flask import request, jsonify
 from . import vendor_bp
-from app.utils import auth_required, role_required, transactional, error, internal_error_response
+from app.utils import transactional, error, internal_error_response
 from app.utils.validation import validate_schema
 from app.schemas.vendor import VendorProfileRequest, VendorDocumentRequest, PayoutSetupRequest
 from app.services.vendor.profile import (
@@ -12,8 +12,6 @@ from app.services.vendor.profile import (
 
 
 @vendor_bp.route("/profile", methods=["POST"])
-@auth_required
-@role_required(["vendor"])
 @validate_schema(VendorProfileRequest)
 def vendor_profile_setup():
     user = request.user
@@ -29,8 +27,6 @@ def vendor_profile_setup():
 
 
 @vendor_bp.route("/upload-document", methods=["POST"])
-@auth_required
-@role_required(["vendor"])
 @validate_schema(VendorDocumentRequest)
 def upload_vendor_document():
     user = request.user
@@ -48,8 +44,6 @@ def upload_vendor_document():
 
 
 @vendor_bp.route("/payout/setup", methods=["POST"])
-@auth_required
-@role_required(["vendor"])
 @validate_schema(PayoutSetupRequest)
 def setup_payout_bank():
     user = request.user

--- a/app/routes/vendor/shop.py
+++ b/app/routes/vendor/shop.py
@@ -5,8 +5,6 @@ from models import db
 from models.shop import Shop, ShopHours, ShopActionLog
 from app.services.vendor.shop import create_shop_for_vendor, ShopValidationError
 from app.utils import (
-    auth_required,
-    role_required,
     transactional,
     error,
     internal_error_response,
@@ -16,8 +14,6 @@ from . import vendor_bp
 
 
 @vendor_bp.route("/shop", methods=["POST"])
-@auth_required
-@role_required(["vendor"])
 def create_shop():
     user = request.user
     data = request.get_json()
@@ -33,8 +29,6 @@ def create_shop():
 
 
 @vendor_bp.route("/shop/edit", methods=["POST"])
-@auth_required
-@role_required(["vendor"])
 def edit_shop():
     user = request.user
     data = request.get_json()
@@ -62,8 +56,6 @@ def edit_shop():
 
 
 @vendor_bp.route("/shop/my", methods=["GET"])
-@auth_required
-@role_required(["vendor"])
 def get_vendor_shop():
     user = request.user
     shop = Shop.query.filter_by(phone=user.phone).first()
@@ -88,8 +80,6 @@ def get_vendor_shop():
 
 
 @vendor_bp.route("/shop/hours", methods=["POST"])
-@auth_required
-@role_required(["vendor"])
 def update_shop_hours():
     user = request.user
     shop = Shop.query.filter_by(phone=user.phone).first()
@@ -128,8 +118,6 @@ def update_shop_hours():
 
 
 @vendor_bp.route("/shop/toggle-status", methods=["POST"])
-@auth_required
-@role_required(["vendor"])
 def toggle_shop_status():
     user = request.user
     data = request.get_json()

--- a/app/routes/vendor/wallet.py
+++ b/app/routes/vendor/wallet.py
@@ -5,13 +5,11 @@ from models import db
 from models.wallet import VendorWallet, VendorWalletTransaction
 from models.vendor import VendorPayoutBank
 from app.services.vendor.wallet import adjust_vendor_balance, InsufficientFunds
-from app.utils import auth_required, role_required, transactional, error, internal_error_response
+from app.utils import transactional, error, internal_error_response
 from . import vendor_bp
 
 
 @vendor_bp.route("/wallet", methods=["GET"])
-@auth_required
-@role_required(["vendor"])
 def get_vendor_wallet():
     user = request.user
     wallet = VendorWallet.query.filter_by(user_phone=user.phone).first()
@@ -26,8 +24,6 @@ def get_vendor_wallet():
 
 
 @vendor_bp.route("/wallet/history", methods=["GET"])
-@auth_required
-@role_required(["vendor"])
 def get_vendor_wallet_history():
     txns = (
         VendorWalletTransaction.query.filter_by(user_phone=request.phone)
@@ -40,8 +36,6 @@ def get_vendor_wallet_history():
 
 
 @vendor_bp.route("/wallet/credit", methods=["POST"])
-@auth_required
-@role_required(["vendor"])
 def credit_vendor_wallet():
     user = request.user
     data = request.get_json()
@@ -67,8 +61,6 @@ def credit_vendor_wallet():
 
 
 @vendor_bp.route("/wallet/debit", methods=["POST"])
-@auth_required
-@role_required(["vendor"])
 def debit_vendor_wallet():
     user = request.user
     data = request.get_json()
@@ -92,8 +84,6 @@ def debit_vendor_wallet():
 
 
 @vendor_bp.route("/wallet/withdraw", methods=["POST"])
-@auth_required
-@role_required(["vendor"])
 def withdraw_vendor_wallet():
     user = request.user
     data = request.get_json()

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -21,6 +21,8 @@ def test_otp_send_rate_limit(monkeypatch):
 def test_order_confirm_rate_limit(monkeypatch):
     app = _load_app(monkeypatch)
     client = app.test_client()
+    token = client.post("/__auth/login_stub", json={"phone": "rlim", "role": "consumer"}).get_json()["data"]["access"]
+    hdr = {"Authorization": f"Bearer {token}"}
     for i in range(21):
-        r = client.post(f"{API_PREFIX}/consumer/order/confirm", json={"dummy": "ok"})
+        r = client.post(f"{API_PREFIX}/consumer/order/confirm", headers=hdr, json={"payment_mode": "cash"})
     assert r.status_code == 429

--- a/tests/test_role_access.py
+++ b/tests/test_role_access.py
@@ -1,0 +1,36 @@
+import pytest
+from app.utils import create_access_token
+from models import db, UserProfile
+from app.version import API_PREFIX
+
+@pytest.fixture
+def tokens(app):
+    with app.app_context():
+        users = {
+            'consumer': UserProfile(phone='c_role', role='consumer'),
+            'vendor': UserProfile(phone='v_role', role='vendor'),
+            'admin': UserProfile(phone='a_role', role='admin'),
+        }
+        db.session.add_all(users.values())
+        db.session.commit()
+        return {
+            role: create_access_token(user.phone, role)
+            for role, user in users.items()
+        }
+
+def test_blueprint_access(client, tokens):
+    c_hdr = {'Authorization': f'Bearer {tokens["consumer"]}'}
+    v_hdr = {'Authorization': f'Bearer {tokens["vendor"]}'}
+    a_hdr = {'Authorization': f'Bearer {tokens["admin"]}'}
+
+    # consumer routes
+    assert client.get(f"{API_PREFIX}/consumer/cart/view", headers=c_hdr).status_code == 200
+    assert client.get(f"{API_PREFIX}/consumer/cart/view", headers=v_hdr).status_code == 403
+
+    # vendor routes
+    assert client.get(f"{API_PREFIX}/vendor/wallet", headers=v_hdr).status_code == 200
+    assert client.get(f"{API_PREFIX}/vendor/wallet", headers=c_hdr).status_code == 403
+
+    # admin routes
+    assert client.get(f"{API_PREFIX}/admin/users", headers=a_hdr).status_code == 200
+    assert client.get(f"{API_PREFIX}/admin/users", headers=v_hdr).status_code == 403


### PR DESCRIPTION
## Summary
- enforce roles for consumer, vendor and admin via blueprint `before_request`
- remove duplicate auth/role decorators from individual routes
- update rate limit test for authenticated calls
- add new authorization test verifying blueprint isolation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aad5bc5708333be0989446d8d2f35