### PR TITLE
Introduce Celery for async operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Example vendor routes:
 
 If `OPENAI_API_KEY` is provided in the environment, the service exposes `/api/v1/agent/query` for chat-based assistance. The endpoint requires authentication and returns the assistant's answer along with suggestions.
 
+### Background workers
+
+Celery with Redis powers asynchronous tasks for heavy operations such as sending notifications or processing item uploads. Set `CELERY_BROKER_URL` and `CELERY_RESULT_BACKEND` to point at your Redis instance. Workers can be started with `celery -A celery_app worker -l info`.
+
 ## Docker
 
 The application can be run in a container using the included `Dockerfile`.

--- a/app/routes/onboarding/auth.py
+++ b/app/routes/onboarding/auth.py
@@ -11,6 +11,7 @@ import logging
 from app.utils import internal_error_response
 from app.utils import error, transactional
 from app.utils.validation import validate_schema
+from app.tasks.notifications import send_whatsapp_message_task
 from app.schemas.auth import SendOTPRequest, VerifyOTPRequest
 from app.utils import (
     create_access_token,
@@ -126,6 +127,10 @@ def send_otp_handler():
         return internal_error_response()
 
     logging.info("[DEBUG] OTP for %s is %s", phone, otp_code)
+    if current_app.config.get("TESTING"):
+        send_whatsapp_message_task(phone, f"Your OTP is {otp_code}")
+    else:
+        send_whatsapp_message_task.delay(phone, f"Your OTP is {otp_code}")
 
     return jsonify({"status": "success", "message": "OTP sent"}), 200
 

--- a/app/tasks/__init__.py
+++ b/app/tasks/__init__.py
@@ -1,0 +1,3 @@
+from celery_app import celery_app
+
+__all__ = ["celery_app"]

--- a/app/tasks/notifications.py
+++ b/app/tasks/notifications.py
@@ -1,0 +1,24 @@
+import os
+import logging
+from celery import shared_task
+from twilio.rest import Client
+
+logger = logging.getLogger(__name__)
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=60)
+def send_whatsapp_message_task(self, to: str, body: str) -> None:
+    """Send WhatsApp message asynchronously via Twilio."""
+    # Skip sending when running tests or missing credentials
+    if os.environ.get("APP_ENV") == "testing":
+        logger.info("[WhatsApp] testing mode - message to %s: %s", to, body)
+        return
+    sid = os.environ.get("TWILIO_ACCOUNT_SID")
+    token = os.environ.get("TWILIO_AUTH_TOKEN")
+    whatsapp_from = os.environ.get("TWILIO_WHATSAPP_FROM")
+    try:
+        client = Client(sid, token)
+        client.messages.create(from_=whatsapp_from, to=f"whatsapp:{to}", body=body)
+        logger.info("[WhatsApp] message sent to %s", to)
+    except Exception as exc:
+        logger.error("WhatsApp send failed: %s", exc)
+        raise self.retry(exc=exc)

--- a/app/tasks/vendor.py
+++ b/app/tasks/vendor.py
@@ -1,0 +1,52 @@
+import logging
+import pandas as pd
+from celery import shared_task
+from models import db
+from models.item import Item
+from app.utils import transactional
+from flask import current_app
+
+logger = logging.getLogger(__name__)
+
+@shared_task(bind=True, max_retries=2, default_retry_delay=30)
+def process_bulk_items_task(self, shop_id: int, dataframe_dict: dict) -> int:
+    """Create items from uploaded DataFrame."""
+    try:
+        df = pd.DataFrame.from_dict(dataframe_dict)
+    except Exception as exc:
+        logger.error("Bulk upload dataframe error: %s", exc)
+        raise self.retry(exc=exc)
+
+    from app import create_app
+    app = current_app._get_current_object() if current_app else create_app()
+    with app.app_context():
+        created = 0
+        for _, row in df.iterrows():
+            try:
+                item = Item(
+                    shop_id=shop_id,
+                    title=row["title"],
+                    brand=row.get("brand"),
+                    price=row["price"],
+                    mrp=row.get("mrp"),
+                    discount=row.get("discount"),
+                    quantity_in_stock=row.get("quantity_in_stock", 0),
+                    unit=row.get("unit"),
+                    pack_size=row.get("pack_size"),
+                    category=row.get("category"),
+                    tags=row.get("tags"),
+                    sku=row.get("sku"),
+                    expiry_date=row.get("expiry_date"),
+                    image_url=row.get("image_url"),
+                    description=row.get("description", ""),
+                    is_available=True,
+                    is_active=True,
+                )
+                db.session.add(item)
+                created += 1
+            except Exception as exc:
+                logger.error("Failed to add item row: %s", exc)
+                continue
+        with transactional("Failed to bulk upload items"):
+            pass
+        return created

--- a/celery_app.py
+++ b/celery_app.py
@@ -1,0 +1,22 @@
+import os
+import logging
+from celery import Celery
+from celery.signals import task_failure, task_retry
+
+broker_url = os.environ.get("CELERY_BROKER_URL", "memory://")
+backend_url = os.environ.get("CELERY_RESULT_BACKEND", "cache+memory://")
+
+celery_app = Celery("habrio", broker=broker_url, backend=backend_url)
+celery_app.conf.task_always_eager = os.environ.get("CELERY_TASK_ALWAYS_EAGER", "0") == "1"
+celery_app.conf.task_eager_propagates = True
+celery_app.conf.task_store_eager_result = False
+
+logger = logging.getLogger(__name__)
+
+@task_failure.connect
+def _log_failure(sender=None, task_id=None, exception=None, **kwargs):
+    logger.error("Task %s failed: %s", getattr(sender, 'name', task_id), exception)
+
+@task_retry.connect
+def _log_retry(sender=None, request=None, reason=None, **kwargs):
+    logger.warning("Task %s retry due to: %s", getattr(sender, 'name', ''), reason)

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,6 @@ pydantic>=2.0
 
 flasgger>=0.9.7
 prometheus-flask-exporter>=0.23.0
+celery
+redis
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ def app_instance():
     os.environ.setdefault('TWILIO_ACCOUNT_SID', 'dummy')
     os.environ.setdefault('TWILIO_AUTH_TOKEN', 'dummy')
     os.environ.setdefault('TWILIO_WHATSAPP_FROM', 'dummy')
+    os.environ.setdefault('CELERY_TASK_ALWAYS_EAGER', '1')
     from app import create_app
     app = create_app()
     app.config.update(

--- a/tests/test_shop_item.py
+++ b/tests/test_shop_item.py
@@ -216,8 +216,8 @@ def test_bulk_upload_items(client, app):
     csv_io.write(df.to_csv(index=False).encode())
     csv_io.seek(0)
     resp = client.post('/api/v1/vendor/item/bulk-upload', data={'file': (csv_io, 'items.csv')}, headers={'Authorization': f'Bearer {token}'}, content_type='multipart/form-data')
-    assert resp.status_code == 200
-    assert '2 items uploaded' in resp.get_json()['message']
+    assert resp.status_code == 202
+    assert 'task_id' in resp.get_json()
     with app.app_context():
         shop = Shop.query.filter_by(phone=phone).first()
         assert Item.query.filter_by(shop_id=shop.id).count() == 2


### PR DESCRIPTION
## Summary
- add Celery configuration with in-memory defaults and logging for retries/failures
- create tasks for WhatsApp notifications and bulk item uploads
- enqueue message send and item bulk upload operations, running synchronously during tests
- add Celery to requirements and update tests for new behavior
- document background worker setup in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ab083621083339a2c62238b094d24