### PR TITLE
Add metrics and alert rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,21 @@ A `docker-compose.yml` is included for local development with PostgreSQL.
 GitHub Actions will run the test suite on every push and pull request to `main`.
 The workflow installs dependencies, runs `pytest`, and ensures the Docker image
 builds successfully.
+
+## Monitoring with Prometheus
+
+A basic Prometheus configuration is provided in `monitoring/prometheus.yml` with
+Alertmanager rules defined in `monitoring/alert_rules.yml`. To run Prometheus
+locally and scrape the application metrics:
+
+```bash
+docker run --network=host \
+  -v $(pwd)/monitoring/prometheus.yml:/etc/prometheus/prometheus.yml \
+  -v $(pwd)/monitoring/alert_rules.yml:/etc/prometheus/alert_rules.yml \
+  prom/prometheus
+```
+
+Navigate to `http://localhost:9090` to explore the metrics dashboard. The
+`/metrics` endpoint of the Flask app exposes request latency histograms,
+database query durations and error counters which feed the provided alerting
+rules.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,6 +10,7 @@ from app.version import API_PREFIX
 from flask_cors import CORS
 from flasgger import Swagger
 from prometheus_flask_exporter import PrometheusMetrics
+from app import metrics as metrics_module
 from flask_limiter.util import get_remote_address
 from flask_migrate import Migrate
 import extensions
@@ -154,6 +155,7 @@ def create_app(config_object=None):
         return resp
 
     db.init_app(app)
+    metrics_module.init_app(app)
     init_tracing(app)
     if app.config.get("DEBUG") or app.config.get("TESTING"):
         with app.app_context():

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -1,0 +1,43 @@
+from flask import request
+from prometheus_client import Histogram, Counter
+from sqlalchemy import event
+import time
+
+from models import db
+
+# Histogram buckets for DB query durations
+DB_QUERY_DURATION = Histogram(
+    "db_query_duration_seconds",
+    "Database query duration in seconds",
+    buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5),
+)
+
+# Counter for HTTP errors
+ERROR_COUNTER = Counter(
+    "flask_error_total",
+    "Count of HTTP responses with status >= 400",
+    ["endpoint", "method", "code"],
+)
+
+
+def init_app(app):
+    """Attach metric hooks to the app and database."""
+
+    with app.app_context():
+        engine = db.engine
+
+        @event.listens_for(engine, "before_cursor_execute")
+        def before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+            conn.info.setdefault("_query_start_time", []).append(time.time())
+
+        @event.listens_for(engine, "after_cursor_execute")
+        def after_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+            start = conn.info.get("_query_start_time").pop(-1)
+            DB_QUERY_DURATION.observe(time.time() - start)
+
+    @app.after_request
+    def track_errors(resp):
+        if resp.status_code >= 400:
+            endpoint = request.endpoint or "unknown"
+            ERROR_COUNTER.labels(endpoint, request.method, resp.status_code).inc()
+        return resp

--- a/metrics.md
+++ b/metrics.md
@@ -1,0 +1,23 @@
+# Metrics and Alerts
+
+The application exposes Prometheus metrics at `/metrics`. The default
+`prometheus-flask-exporter` integration provides request counters and latency
+histograms. Additional metrics are defined to capture database query durations
+and HTTP error counts.
+
+## Database metrics
+- `db_query_duration_seconds` – histogram of SQL execution time.
+- `flask_error_total` – counter of responses with status codes >= 400.
+
+## Running Prometheus locally
+Use the provided configuration files in the `monitoring/` directory:
+
+```bash
+docker run --network=host \
+  -v $(pwd)/monitoring/prometheus.yml:/etc/prometheus/prometheus.yml \
+  -v $(pwd)/monitoring/alert_rules.yml:/etc/prometheus/alert_rules.yml \
+  prom/prometheus
+```
+
+Open <http://localhost:9090> to query metrics and inspect the dashboards.
+Alerts defined in `alert_rules.yml` fire when SLO thresholds are violated.

--- a/monitoring/alert_rules.yml
+++ b/monitoring/alert_rules.yml
@@ -1,0 +1,24 @@
+groups:
+- name: habrio_slo
+  rules:
+  - alert: HighRequestLatency
+    expr: histogram_quantile(0.99, sum(rate(flask_http_request_duration_seconds_bucket[5m])) by (le)) > 0.5
+    for: 2m
+    labels:
+      severity: page
+    annotations:
+      summary: "99th percentile request latency too high"
+  - alert: HighDbLatency
+    expr: histogram_quantile(0.99, sum(rate(db_query_duration_seconds_bucket[5m])) by (le)) > 0.1
+    for: 2m
+    labels:
+      severity: page
+    annotations:
+      summary: "99th percentile DB query latency too high"
+  - alert: HighErrorRate
+    expr: sum(rate(flask_error_total[5m])) / sum(rate(flask_http_request_total[5m])) > 0.05
+    for: 5m
+    labels:
+      severity: page
+    annotations:
+      summary: "More than 5% of requests return errors"

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+scrape_configs:
+  - job_name: 'habrio'
+    static_configs:
+      - targets: ['web:80']
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ['alertmanager:9093']
+rule_files:
+  - 'alert_rules.yml'


### PR DESCRIPTION
## Summary
- introduce `app.metrics` with Prometheus histograms for DB queries and error counter
- wire metrics into `create_app`
- provide Prometheus config and Alertmanager rules
- document monitoring setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aba87d9e4833390961c90bdd8e856