### PR TITLE
Integrate coverage checks and add API segregation tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    - name: Run tests
-      run: pytest -q
+        pip install pytest-cov
+    - name: Run tests with coverage
+      run: pytest --cov=app --cov=agent --cov=models --cov=extensions --cov-report=term-missing --cov-fail-under=90
     - name: Build Docker image
       run: docker build -t habrio:ci .

--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ A `docker-compose.yml` is included for local development with PostgreSQL.
 
 ## Continuous Integration
 
-GitHub Actions will run the test suite on every push and pull request to `main`.
-The workflow installs dependencies, runs `pytest`, and ensures the Docker image
-builds successfully.
+GitHub Actions runs the test suite on every push and pull request to `main`.
+The workflow installs dependencies, executes the tests with `pytest-cov`, and
+fails if overall coverage drops below 90%.
 
 ## Monitoring with Prometheus
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,5 @@ opentelemetry-instrumentation-sqlalchemy
 opentelemetry-instrumentation-requests
 opentelemetry-exporter-otlp
 
+pytest>=8.0
+pytest-cov>=4.1

--- a/tests/test_contract_access.py
+++ b/tests/test_contract_access.py
@@ -1,0 +1,42 @@
+import pytest
+from app.utils import create_access_token
+from models import db, UserProfile
+from app.version import API_PREFIX
+
+@pytest.fixture
+def tokens(app):
+    with app.app_context():
+        users = {
+            'consumer': UserProfile(phone='contract_c', role='consumer'),
+            'vendor': UserProfile(phone='contract_v', role='vendor'),
+            'admin': UserProfile(phone='contract_a', role='admin'),
+        }
+        db.session.add_all(users.values())
+        db.session.commit()
+        return {role: create_access_token(user.phone, role) for role, user in users.items()}
+
+def _hdr(token):
+    return {'Authorization': f'Bearer {token}'}
+
+def test_role_contracts(client, tokens):
+    c = _hdr(tokens['consumer'])
+    v = _hdr(tokens['vendor'])
+    a = _hdr(tokens['admin'])
+
+    # consumer allowed
+    assert client.get(f"{API_PREFIX}/consumer/wallet", headers=c).status_code == 200
+    # consumer forbidden on vendor and admin routes
+    assert client.get(f"{API_PREFIX}/vendor/wallet", headers=c).status_code == 403
+    assert client.get(f"{API_PREFIX}/admin/users", headers=c).status_code == 403
+
+    # vendor allowed
+    assert client.get(f"{API_PREFIX}/vendor/wallet", headers=v).status_code == 200
+    # vendor forbidden on consumer and admin routes
+    assert client.get(f"{API_PREFIX}/consumer/wallet", headers=v).status_code == 403
+    assert client.get(f"{API_PREFIX}/admin/users", headers=v).status_code == 403
+
+    # admin allowed
+    assert client.get(f"{API_PREFIX}/admin/users", headers=a).status_code == 200
+    # admin forbidden on consumer and vendor routes
+    assert client.get(f"{API_PREFIX}/consumer/wallet", headers=a).status_code == 403
+    assert client.get(f"{API_PREFIX}/vendor/wallet", headers=a).status_code == 403


### PR DESCRIPTION
## Summary
- enforce coverage in CI using pytest-cov
- document coverage enforcement in README
- add pytest and pytest-cov to requirements
- add contract test covering consumer/vendor/admin access boundaries

## Testing
- `pytest -q`
- `pytest --cov=app --cov=agent --cov=models --cov=extensions --cov-report=term-missing --cov-fail-under=90` *(fails: coverage < 90%)*

------
https://chatgpt.com/codex/tasks/task_e_688aff4c8538833393aa63c442d4aecb