### PR TITLE
Add composite order index and bigints

### DIFF
--- a/migrations/versions/3c870a7e6b9d_add_order_index_and_bigints.py
+++ b/migrations/versions/3c870a7e6b9d_add_order_index_and_bigints.py
@@ -1,0 +1,54 @@
+"""add order composite index and bigint keys
+
+Revision ID: 3c870a7e6b9d
+Revises: 055cb63f2358
+Create Date: 2025-07-31 06:15:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '3c870a7e6b9d'
+down_revision = '055cb63f2358'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index('ix_order_shop_status', 'order', ['shop_id', 'status'])
+    op.alter_column('order', 'id', type_=sa.BigInteger())
+    op.alter_column('order', 'shop_id', type_=sa.BigInteger())
+    op.alter_column('order_item', 'id', type_=sa.BigInteger())
+    op.alter_column('order_item', 'order_id', type_=sa.BigInteger())
+    op.alter_column('order_messages', 'id', type_=sa.BigInteger())
+    op.alter_column('order_messages', 'order_id', type_=sa.BigInteger())
+    op.alter_column('order_status_log', 'id', type_=sa.BigInteger())
+    op.alter_column('order_status_log', 'order_id', type_=sa.BigInteger())
+    op.alter_column('order_action_log', 'id', type_=sa.BigInteger())
+    op.alter_column('order_action_log', 'order_id', type_=sa.BigInteger())
+    op.alter_column('order_rating', 'id', type_=sa.BigInteger())
+    op.alter_column('order_rating', 'order_id', type_=sa.BigInteger())
+    op.alter_column('order_issue', 'id', type_=sa.BigInteger())
+    op.alter_column('order_issue', 'order_id', type_=sa.BigInteger())
+    op.alter_column('order_return', 'id', type_=sa.BigInteger())
+    op.alter_column('order_return', 'order_id', type_=sa.BigInteger())
+
+
+def downgrade():
+    op.drop_index('ix_order_shop_status', table_name='order')
+    op.alter_column('order_return', 'order_id', type_=sa.Integer())
+    op.alter_column('order_return', 'id', type_=sa.Integer())
+    op.alter_column('order_issue', 'order_id', type_=sa.Integer())
+    op.alter_column('order_issue', 'id', type_=sa.Integer())
+    op.alter_column('order_rating', 'order_id', type_=sa.Integer())
+    op.alter_column('order_rating', 'id', type_=sa.Integer())
+    op.alter_column('order_action_log', 'order_id', type_=sa.Integer())
+    op.alter_column('order_action_log', 'id', type_=sa.Integer())
+    op.alter_column('order_status_log', 'order_id', type_=sa.Integer())
+    op.alter_column('order_status_log', 'id', type_=sa.Integer())
+    op.alter_column('order_messages', 'order_id', type_=sa.Integer())
+    op.alter_column('order_messages', 'id', type_=sa.Integer())
+    op.alter_column('order_item', 'order_id', type_=sa.Integer())
+    op.alter_column('order_item', 'id', type_=sa.Integer())
+    op.alter_column('order', 'shop_id', type_=sa.Integer())
+    op.alter_column('order', 'id', type_=sa.Integer())

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,4 +1,8 @@
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import BigInteger, Integer
+
+# Use BigInteger in production but fall back to Integer for SQLite
+BIGINT = BigInteger().with_variant(Integer, "sqlite")
 
 db = SQLAlchemy()
 

--- a/models/cart.py
+++ b/models/cart.py
@@ -1,13 +1,13 @@
-from models import db
+from models import db, BIGINT
 from datetime import datetime
 
 class CartItem(db.Model):
     __tablename__ = "cart_item"
 
-    id = db.Column(db.Integer, primary_key=True)
+    id = db.Column(BIGINT, primary_key=True)
     user_phone = db.Column(db.String(15), db.ForeignKey("user_profile.phone"), nullable=False)
-    shop_id = db.Column(db.Integer, db.ForeignKey("shop.id"), nullable=False)
-    item_id = db.Column(db.Integer, db.ForeignKey("item.id"), nullable=False)
+    shop_id = db.Column(BIGINT, db.ForeignKey("shop.id"), nullable=False)
+    item_id = db.Column(BIGINT, db.ForeignKey("item.id"), nullable=False)
     quantity = db.Column(db.Integer, default=1)
     added_at = db.Column(db.DateTime, default=datetime.utcnow)
     last_updated = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/models/item.py
+++ b/models/item.py
@@ -1,12 +1,12 @@
 # --- models/item.py ---
-from models import db
+from models import db, BIGINT
 from datetime import datetime
 
 class Item(db.Model):
     __tablename__ = "item"
 
-    id = db.Column(db.Integer, primary_key=True)
-    shop_id = db.Column(db.Integer, db.ForeignKey("shop.id"), nullable=False)
+    id = db.Column(BIGINT, primary_key=True)
+    shop_id = db.Column(BIGINT, db.ForeignKey("shop.id"), nullable=False)
 
     # Core details
     title = db.Column(db.String(100), nullable=False)             # Replaces 'name'

--- a/models/order.py
+++ b/models/order.py
@@ -1,4 +1,5 @@
 from sqlalchemy import Column, Integer, String, Float, Text, DateTime, ForeignKey
+from models import BIGINT
 from sqlalchemy.sql import func
 from models import db
 from datetime import datetime
@@ -6,9 +7,12 @@ from datetime import datetime
 
 class Order(db.Model):
     __tablename__ = "order"
-    id = Column(Integer, primary_key=True)
+    __table_args__ = (
+        db.Index("ix_order_shop_status", "shop_id", "status"),
+    )
+    id = Column(BIGINT, primary_key=True)
     user_phone = Column(String(15), ForeignKey("user_profile.phone"), nullable=False)
-    shop_id = Column(Integer, ForeignKey("shop.id"), nullable=False)
+    shop_id = Column(BIGINT, ForeignKey("shop.id"), nullable=False)
     status = Column(String(50), default="pending")  # pending, accepted, modified, confirmed, cancelled, delivered
     payment_mode = Column(String(10), nullable=False)  # wallet or cash
     payment_status = Column(String(20), default="unpaid")  # unpaid, paid, refunded, partially_refunded
@@ -25,9 +29,9 @@ class Order(db.Model):
 
 class OrderItem(db.Model):
     __tablename__ = "order_item"
-    id = db.Column(db.Integer, primary_key=True)
-    order_id = db.Column(db.Integer, db.ForeignKey("order.id"), nullable=False)
-    item_id = db.Column(db.Integer, nullable=False)
+    id = db.Column(BIGINT, primary_key=True)
+    order_id = db.Column(BIGINT, db.ForeignKey("order.id"), nullable=False)
+    item_id = db.Column(BIGINT, nullable=False)
 
     # Add these missing fields:
     name = db.Column(db.String(255))
@@ -50,8 +54,8 @@ class OrderItem(db.Model):
 
 class OrderMessage(db.Model):
     __tablename__ = "order_messages"
-    id = Column(Integer, primary_key=True)
-    order_id = Column(Integer, ForeignKey("order.id"), nullable=False)
+    id = Column(BIGINT, primary_key=True)
+    order_id = Column(BIGINT, ForeignKey("order.id"), nullable=False)
     sender_phone = Column(String(15), nullable=False)
     message = Column(Text, nullable=False)
     timestamp = Column(DateTime, default=func.now())
@@ -68,8 +72,8 @@ class OrderMessage(db.Model):
 
 class OrderStatusLog(db.Model):
     __tablename__ = "order_status_log"
-    id = Column(Integer, primary_key=True)
-    order_id = Column(Integer, ForeignKey("order.id"), nullable=False)
+    id = Column(BIGINT, primary_key=True)
+    order_id = Column(BIGINT, ForeignKey("order.id"), nullable=False)
     status = Column(String(30), nullable=False)
     updated_by = Column(String(15), nullable=False)
     timestamp = Column(DateTime, default=func.now())
@@ -85,8 +89,8 @@ class OrderStatusLog(db.Model):
 
 class OrderActionLog(db.Model):
     __tablename__ = "order_action_log"
-    id = Column(Integer, primary_key=True)
-    order_id = Column(Integer, ForeignKey("order.id"), nullable=False)
+    id = Column(BIGINT, primary_key=True)
+    order_id = Column(BIGINT, ForeignKey("order.id"), nullable=False)
     action_type = Column(String(50), nullable=False)
     actor_phone = Column(String(15), nullable=False)
     details = Column(Text, nullable=True)
@@ -95,9 +99,8 @@ class OrderActionLog(db.Model):
 
 class OrderRating(db.Model):
     __tablename__ = "order_rating"
-
-    id = db.Column(db.Integer, primary_key=True)
-    order_id = db.Column(db.Integer, db.ForeignKey("order.id"), nullable=False)
+    id = db.Column(BIGINT, primary_key=True)
+    order_id = db.Column(BIGINT, db.ForeignKey("order.id"), nullable=False)
     user_phone = db.Column(db.String(15), nullable=False)
     rating = db.Column(db.Integer, nullable=False)
     review = db.Column(db.String(250))
@@ -113,8 +116,8 @@ class OrderRating(db.Model):
 
 class OrderIssue(db.Model):
     __tablename__ = "order_issue"
-    id = db.Column(db.Integer, primary_key=True)
-    order_id = db.Column(db.Integer, db.ForeignKey("order.id"), nullable=False)
+    id = db.Column(BIGINT, primary_key=True)
+    order_id = db.Column(BIGINT, db.ForeignKey("order.id"), nullable=False)
     user_phone = db.Column(db.String, nullable=False)
     issue_type = db.Column(db.String(50), nullable=False)  # e.g., "damaged_item", "missing_item"
     description = db.Column(db.Text, nullable=True)
@@ -136,10 +139,9 @@ class OrderIssue(db.Model):
 
 class OrderReturn(db.Model):
     __tablename__ = "order_return"
-
-    id = db.Column(db.Integer, primary_key=True)
-    order_id = db.Column(db.Integer, db.ForeignKey("order.id"), nullable=False)
-    item_id = db.Column(db.Integer, db.ForeignKey("item.id"), nullable=True)  # Null for full return
+    id = db.Column(BIGINT, primary_key=True)
+    order_id = db.Column(BIGINT, db.ForeignKey("order.id"), nullable=False)
+    item_id = db.Column(BIGINT, db.ForeignKey("item.id"), nullable=True)  # Null for full return
     quantity = db.Column(db.Integer, nullable=False, default=1)
     reason = db.Column(db.String(255))
     initiated_by = db.Column(db.String(20))  # 'consumer' or 'vendor'

--- a/models/shop.py
+++ b/models/shop.py
@@ -1,8 +1,8 @@
-from models import db
+from models import db, BIGINT
 from datetime import datetime
 
 class Shop(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
+    id = db.Column(BIGINT, primary_key=True)
     shop_name = db.Column(db.String(100), nullable=False)         # renamed from name
     shop_type = db.Column(db.String(50), nullable=False)          # renamed from type
     society = db.Column(db.String(100), nullable=False)
@@ -30,8 +30,8 @@ class Shop(db.Model):
 class ShopHours(db.Model):
     __tablename__ = "shop_hours"
 
-    id = db.Column(db.Integer, primary_key=True)
-    shop_id = db.Column(db.Integer, db.ForeignKey("shop.id"), nullable=False)
+    id = db.Column(BIGINT, primary_key=True)
+    shop_id = db.Column(BIGINT, db.ForeignKey("shop.id"), nullable=False)
     day_of_week = db.Column(db.Integer, nullable=False)  # 0 = Monday, 6 = Sunday
     open_time = db.Column(db.Time, nullable=True)
     close_time = db.Column(db.Time, nullable=True)
@@ -46,8 +46,8 @@ class ShopHours(db.Model):
         }
 
 class ShopActionLog(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
-    shop_id = db.Column(db.Integer, db.ForeignKey("shop.id"), nullable=False)
+    id = db.Column(BIGINT, primary_key=True)
+    shop_id = db.Column(BIGINT, db.ForeignKey("shop.id"), nullable=False)
     action = db.Column(db.String(50))  # 'opened' or 'closed'
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
 

--- a/models/user.py
+++ b/models/user.py
@@ -1,12 +1,12 @@
 # --- models/user.py ---
-from models import db
+from models import db, BIGINT
 from datetime import datetime
 
 # --- OTP Model ---
 class OTP(db.Model):
     __tablename__ = "otp"
 
-    id = db.Column(db.Integer, primary_key=True)
+    id = db.Column(BIGINT, primary_key=True)
     phone = db.Column(db.String(15), nullable=False)
     otp = db.Column(db.String(6), nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
@@ -42,7 +42,7 @@ class UserProfile(db.Model):
 class ConsumerProfile(db.Model):
     __tablename__ = "consumer_profile"
 
-    id = db.Column(db.Integer, primary_key=True)
+    id = db.Column(BIGINT, primary_key=True)
     user_phone = db.Column(db.String(15), db.ForeignKey("user_profile.phone"), unique=True, nullable=False)
     name = db.Column(db.String(100), nullable=False)
     city = db.Column(db.String(50), nullable=False)

--- a/models/vendor.py
+++ b/models/vendor.py
@@ -1,11 +1,11 @@
-from models import db
+from models import db, BIGINT
 from datetime import datetime
 
 
 class VendorProfile(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
+    id = db.Column(BIGINT, primary_key=True)
     user_phone = db.Column(db.String, db.ForeignKey("user_profile.phone"), unique=True)
-    shop_id = db.Column(db.Integer, db.ForeignKey("shop.id"), unique=True)
+    shop_id = db.Column(BIGINT, db.ForeignKey("shop.id"), unique=True)
     business_name = db.Column(db.String)
     gst_number = db.Column(db.String)
     address = db.Column(db.String)
@@ -15,7 +15,7 @@ class VendorProfile(db.Model):
 
 
 class VendorDocument(db.Model):
-    id = db.Column(db.Integer, primary_key=True)
+    id = db.Column(BIGINT, primary_key=True)
     vendor_phone = db.Column(db.String, db.ForeignKey("user_profile.phone"))
     document_type = db.Column(db.String)  # e.g., 'aadhaar', 'pan', 'shop_license'
     file_url = db.Column(db.String)
@@ -25,7 +25,7 @@ class VendorDocument(db.Model):
 class VendorPayoutBank(db.Model):
     __tablename__ = "vendor_payout_bank"
 
-    id = db.Column(db.Integer, primary_key=True)
+    id = db.Column(BIGINT, primary_key=True)
     user_phone = db.Column(db.String(15), db.ForeignKey("user_profile.phone"), unique=True, nullable=False)
     bank_name = db.Column(db.String(100), nullable=False)
     account_number = db.Column(db.String(50), nullable=False)

--- a/models/wallet.py
+++ b/models/wallet.py
@@ -1,11 +1,12 @@
 from sqlalchemy import Column, Integer, String, Numeric, Text, DateTime
+from models import BIGINT
 from sqlalchemy.sql import func
 from models import db
 
 
 class ConsumerWallet(db.Model):
     __tablename__ = "consumer_wallet"
-    id = Column(Integer, primary_key=True)
+    id = Column(BIGINT, primary_key=True)
     user_phone = Column(String(15), nullable=False, unique=True)
     balance = Column(Numeric(10, 2), default=0.00)
     created_at = Column(DateTime, default=func.now())
@@ -14,7 +15,7 @@ class ConsumerWallet(db.Model):
 
 class WalletTransaction(db.Model):
     __tablename__ = "wallet_transaction"
-    id = Column(Integer, primary_key=True)
+    id = Column(BIGINT, primary_key=True)
     user_phone = Column(String(15), nullable=False)
     amount = Column(Numeric(10, 2), nullable=False)
     type = Column(String(20), nullable=False)  # e.g. debit, credit, refund
@@ -37,7 +38,7 @@ class WalletTransaction(db.Model):
 
 class VendorWallet(db.Model):
     __tablename__ = "vendor_wallet"
-    id = Column(Integer, primary_key=True)
+    id = Column(BIGINT, primary_key=True)
     user_phone = Column(String(15), nullable=False, unique=True)
     balance = Column(Numeric(10, 2), default=0.00)
     created_at = Column(DateTime, default=func.now())
@@ -46,7 +47,7 @@ class VendorWallet(db.Model):
 
 class VendorWalletTransaction(db.Model):
     __tablename__ = "vendor_wallet_transaction"
-    id = Column(Integer, primary_key=True)
+    id = Column(BIGINT, primary_key=True)
     user_phone = Column(String(15), nullable=False)
     amount = Column(Numeric(10, 2), nullable=False)
     type = Column(String(20), nullable=False)  # credit, debit

--- a/tests/test_query_plans.py
+++ b/tests/test_query_plans.py
@@ -1,0 +1,16 @@
+import pytest
+from sqlalchemy import text, inspect
+from models import db
+from models.order import Order
+
+
+def test_order_shop_status_index_used(app):
+    with app.app_context():
+        db.create_all()
+        insp = inspect(db.engine)
+        assert any(ix['name'] == 'ix_order_shop_status' for ix in insp.get_indexes('order'))
+        db.session.add(Order(user_phone='u', shop_id=1, status='pending', payment_mode='cash', payment_status='unpaid', total_amount=1))
+        db.session.commit()
+        plan_rows = db.session.execute(text("EXPLAIN QUERY PLAN SELECT * FROM 'order' WHERE shop_id=1 AND status='pending'"))
+        plan = " ".join(r[3] for r in plan_rows)
+        assert 'USING INDEX ix_order_shop_status' in plan


### PR DESCRIPTION
## Summary
- support BIGINT autoincrement columns via helper constant
- switch models to BIGINT primary keys
- index `Order` on `(shop_id, status)`
- create migration for index and bigint conversions
- test query plan to ensure index usage

## Testing
- `pytest tests/test_query_plans.py::test_order_shop_status_index_used -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b090c5eb08333b91b93c36a424362