### PR TITLE
Make pandas optional for CLI imports

### DIFF
--- a/app/routes/vendor/items.py
+++ b/app/routes/vendor/items.py
@@ -1,6 +1,5 @@
 from flask import request, jsonify, current_app
 from datetime import datetime
-import pandas as pd
 from werkzeug.utils import secure_filename
 from models.item import Item
 from models.shop import Shop
@@ -129,6 +128,7 @@ def bulk_upload_items():
     filename = secure_filename(file.filename)
     ext = filename.split('.')[-1].lower()
     try:
+        import pandas as pd  # Imported lazily to avoid dependency issues during CLI operations
         if ext == "csv":
             df = pd.read_csv(file)
         elif ext in ["xls", "xlsx"]:


### PR DESCRIPTION
## Summary
- avoid importing pandas when the vendor blueprint is loaded
- lazy import pandas only in the bulk upload endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688b34fbb7e083339cf66545ace00647