### PR TITLE
Disable Twilio OTP flow

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,7 +5,6 @@ from app.logging import configure_logging
 from app.errors import errors_bp
 from app.cli import register_cli
 from app.api import register_api_v1
-from app.routes.onboarding import auth as auth_routes
 from app.version import API_PREFIX
 from flask_cors import CORS
 from flasgger import Swagger
@@ -38,7 +37,6 @@ def create_app(config_object=None):
 
     configure_logging(app)
     register_cli(app)
-    auth_routes.init_twilio(app)
 
     # Optional OpenAI configuration for the assistant
     openai_key = os.environ.get("OPENAI_API_KEY")

--- a/app/tasks/notifications.py
+++ b/app/tasks/notifications.py
@@ -1,24 +1,10 @@
-import os
 import logging
 from celery import shared_task
-from twilio.rest import Client
 
 logger = logging.getLogger(__name__)
 
+
 @shared_task(bind=True, max_retries=3, default_retry_delay=60)
 def send_whatsapp_message_task(self, to: str, body: str) -> None:
-    """Send WhatsApp message asynchronously via Twilio."""
-    # Skip sending when running tests or missing credentials
-    if os.environ.get("APP_ENV") == "testing":
-        logger.info("[WhatsApp] testing mode - message to %s: %s", to, body)
-        return
-    sid = os.environ.get("TWILIO_ACCOUNT_SID")
-    token = os.environ.get("TWILIO_AUTH_TOKEN")
-    whatsapp_from = os.environ.get("TWILIO_WHATSAPP_FROM")
-    try:
-        client = Client(sid, token)
-        client.messages.create(from_=whatsapp_from, to=f"whatsapp:{to}", body=body)
-        logger.info("[WhatsApp] message sent to %s", to)
-    except Exception as exc:
-        logger.error("WhatsApp send failed: %s", exc)
-        raise self.retry(exc=exc)
+    """Log message instead of sending via Twilio."""
+    logger.info("[WhatsApp disabled] message to %s: %s", to, body)


### PR DESCRIPTION
## Summary
- Remove Twilio client initialization and message sending
- Log OTP codes instead of sending messages
- Stub WhatsApp task to log messages only

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894d94eeb008333b937f3f92fb6a390