### PR TITLE
Handle invalid OTP payloads

### DIFF
--- a/app/utils/validation.py
+++ b/app/utils/validation.py
@@ -19,8 +19,13 @@ def validate_schema(schema):
     def decorator(fn):
         @wraps(fn)
         def wrapper(*args, **kwargs):
+            payload = request.get_json(silent=True)
+            if not isinstance(payload, dict):
+                return validation_error_response([
+                    {"loc": [], "msg": "JSON body must be an object", "type": "type_error"}
+                ])
             try:
-                obj = schema(**(request.get_json() or {}))
+                obj = schema(**payload)
             except ValidationError as ve:
                 return validation_error_response(ve.errors())
             request.validated_data = obj

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -46,6 +46,17 @@ def test_send_otp_no_phone(client):
     assert response.get_json()['status'] == 'error'
 
 
+def test_send_otp_invalid_json_structure(client):
+    response = client.post(
+        '/api/v1/send-otp',
+        data='["9111111111"]',
+        headers={'Content-Type': 'application/json'},
+        environ_overrides={'REMOTE_ADDR': '10.0.0.2'}
+    )
+    assert response.status_code == 400
+    assert response.get_json()['status'] == 'error'
+
+
 def test_verify_otp_success_creates_profile(client, app):
     phone = '1112223333'
     send_otp(client, phone)


### PR DESCRIPTION
## Summary
- avoid send-otp crashes by safely reading phone number for rate limits
- treat non-object JSON bodies as validation errors
- test OTP endpoint with invalid JSON

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894de2be878833380c1edcaa32e8256