### PR TITLE
Fix telemetry exporter causing span export errors

### DIFF
--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -1,7 +1,11 @@
 from opentelemetry import trace
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+from opentelemetry.sdk.trace.export import (
+    BatchSpanProcessor,
+    ConsoleSpanExporter,
+    SimpleSpanProcessor,
+)
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.instrumentation.flask import FlaskInstrumentor
 from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
@@ -19,7 +23,7 @@ def init_tracing(app):
 
     provider = TracerProvider(resource=Resource.create({"service.name": service_name}))
     if app.config.get("TESTING"):
-        processor = BatchSpanProcessor(ConsoleSpanExporter())
+        processor = SimpleSpanProcessor(ConsoleSpanExporter())
     else:
         processor = BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint))
     provider.add_span_processor(processor)

--- a/debug.txt
+++ b/debug.txt
@@ -1,0 +1,8 @@
+Issue:
+When running tests or the /api/v1/send-otp endpoint, OpenTelemetry's BatchSpanProcessor with ConsoleSpanExporter tried to export spans after the test framework closed stdout, resulting in "ValueError: I/O operation on closed file" and 500 errors.
+
+Fix:
+Replaced BatchSpanProcessor with SimpleSpanProcessor in app/telemetry.py when TESTING is enabled. This exports spans synchronously, avoiding background flush after stdout is closed.
+
+Other Modifications:
+No changes needed for production configuration; OTLP exporter remains for non-testing environments.


### PR DESCRIPTION
## Summary
- avoid console exporter writing to closed stdout during tests
- add debugging notes on telemetry span export error

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894e5797e7c8333a2f0fb97d5a7def2